### PR TITLE
ENH: FormHandler edits on files should infer type

### DIFF
--- a/gramex/data.py
+++ b/gramex/data.py
@@ -673,8 +673,9 @@ def _filter_frame(data, meta, controls, args, source='select', id=[]):
         original_data.drop(data.index, inplace=True)
         return data
     elif source == 'update':
+        conv = {k: v.type for k, v in data.dtypes.items()}
         for key, val in cols_for_update.items():
-            original_data.loc[data.index, key] = val
+            original_data.loc[data.index, key] = conv[key](val)
         return data
     else:
         # Apply controls

--- a/testlib/test_data.py
+++ b/testlib/test_data.py
@@ -14,6 +14,7 @@ from orderedattrdict import AttrDict
 from nose.plugins.skip import SkipTest
 from nose.tools import eq_, ok_, assert_raises
 from pandas.util.testing import assert_frame_equal as afe
+from pandas.util.testing import assert_series_equal as ase
 import dbutils
 from . import folder, sales_file
 
@@ -441,11 +442,32 @@ class TestInsert(unittest.TestCase):
 
 
 class TestEdit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.edit_file = sales_file + '.edit.xlsx'
+        shutil.copy(sales_file, cls.edit_file)
+        cls.tmpfiles = [cls.edit_file]
+
     def test_update(self):
-        raise SkipTest('TODO: write update test cases')
+        args = {
+            'देश': ['भारत'],
+            'city': ['Hyderabad'],
+            'product': ['Crème'],
+            'sales': ['0']
+        }
+        data = gramex.cache.open(self.edit_file, 'xlsx')
+        types_original = data.dtypes
+        gramex.data.update(data, args=args, id=['देश', 'city', 'product'])
+        ase(types_original, data.dtypes)
 
     def test_delete(self):
         raise SkipTest('TODO: write delete test cases')
+
+    @classmethod
+    def tearDownClass(cls):
+        for path in cls.tmpfiles:
+            if os.path.exists(path):
+                os.remove(path)
 
 
 class TestDownload(unittest.TestCase):


### PR DESCRIPTION
## Summary
FormHandler edits on files/dataframes should infer type from original data.

```python
import gramex.data

url = 'https://learn.gramener.com/guide/formhandler/flags?_format=csv'
df = pd.read_csv(url)
# ?Continent=Asia&c1=101   --  handler.args will also store values as strings.
count = gramex.data.update(df, args={'Continent': ['Asia'], 'c1': ['101']}, id=['Continent'])
```

*Currently,* this would store `c1` with string `'101'`

This PR fixes it.