### PR TITLE
ENH: --watch=False / init(watch=False) disables autoreloading gramex.yaml

### DIFF
--- a/gramex/__init__.py
+++ b/gramex/__init__.py
@@ -264,15 +264,16 @@ def init(force_reload=False, **kwargs):
     from . import services
     globals()['service'] = services.info    # gramex.service = gramex.services.info
 
-    # Set up a watch on config files (including imported files)
-    from services import watcher
-    watcher.watch('gramex-reconfig', paths=config_files, on_modified=lambda event: init())
-
     # Override final configurations
     final_config = +config_layers
     # --settings.debug => log.root.level = True
     if final_config.app.get('settings', {}).get('debug', False):
         final_config.log.root.level = logging.DEBUG
+
+    # Set up a watch on config files (including imported files)
+    if final_config.app.get('watch', True):
+        from services import watcher
+        watcher.watch('gramex-reconfig', paths=config_files, on_modified=lambda event: init())
 
     # Run all valid services. (The "+" before config_chain merges the chain)
     # Services may return callbacks to be run at the end

--- a/gramex/gramex.yaml
+++ b/gramex/gramex.yaml
@@ -223,7 +223,7 @@ eventlog:
 # The `app:` section defines the settings for the main Gramex application
 app:
     browser: False                      # Open the browser on startup
-
+    watch: True                         # To watch gramex.yaml changes and run init
     listen:
         port: 9988                      # Port to bind to. (8888 used by Jupyter)
         xheaders: True                  # X-Real-Ip/X-Forwarded-For and X-Scheme/X-Forwarded-Proto override remote IP, scheme


### PR DESCRIPTION
- Allows user to disable watching `gramex.yaml`, which disables autoreloading `gramex.conf` via `gramex --nowatch`
- Also, provides `gramex.init(watch=True)` to explicitly not watch files.