### PR TITLE
BUG: rename NLG modules to avoid conflict

### DIFF
--- a/gramex/apps/nlg/__init__.py
+++ b/gramex/apps/nlg/__init__.py
@@ -1,1 +1,1 @@
-from .search import templatize  # NOQA: F401
+from .nlgsearch import templatize       # NOQA: F401

--- a/gramex/apps/nlg/gramex.yaml
+++ b/gramex/apps/nlg/gramex.yaml
@@ -11,7 +11,7 @@ url:
       headers:
         Cache-Control: no-store
       xsrf_cookies: false
-      function: gramex.apps.nlg.webapp.init_form
+      function: gramex.apps.nlg.nlgapp.init_form
       redirect:
         url: /$YAMLURL/../?tab=nlg&action=edit
   tablepreview-$*:
@@ -30,14 +30,14 @@ url:
     pattern: /$YAMLURL/initconf
     handler: FunctionHandler
     kwargs:
-      function: gramex.apps.nlg.webapp.get_init_config
+      function: gramex.apps.nlg.nlgapp.get_init_config
       headers:
         Content-Type: application/json
   textproc-$*:
     pattern: /$YAMLURL/textproc
     handler: FunctionHandler
     kwargs:
-      function: gramex.apps.nlg.webapp.process_template
+      function: gramex.apps.nlg.nlgapp.process_template
       xsrf_cookies: false
       headers:
         Content-Type: application/json
@@ -45,7 +45,7 @@ url:
     pattern: /$YAMLURL/render-template
     handler: FunctionHandler
     kwargs:
-      function: gramex.apps.nlg.webapp.render_template
+      function: gramex.apps.nlg.nlgapp.render_template
       xsrf_cookies: false
       headers:
         Content-Type: application/json
@@ -53,7 +53,7 @@ url:
     pattern: /$YAMLURL/get-gramopts
     handler: FunctionHandler
     kwargs:
-      function: gramex.apps.nlg.webapp.get_gramopts
+      function: gramex.apps.nlg.nlgapp.get_gramopts
       xsrf_cookies: false
       headers:
         Content-Type: application/json
@@ -61,13 +61,13 @@ url:
     pattern: /$YAMLURL/save-config
     handler: FunctionHandler
     kwargs:
-      function: gramex.apps.nlg.webapp.save_config
+      function: gramex.apps.nlg.nlgapp.save_config
       xsrf_cookies: false
   edit-narrative-$*:
     pattern: /$YAMLURL/edit-narrative
     handler: FunctionHandler
     kwargs:
-      function: gramex.apps.nlg.webapp.edit_narrative
+      function: gramex.apps.nlg.nlgapp.edit_narrative
       auth:
         login_url: /$YAMLURL/../../login/
       redirect:
@@ -76,4 +76,4 @@ url:
     pattern: /$YAMLURL/render-live-template
     handler: FunctionHandler
     kwargs:
-      function: gramex.apps.nlg.webapp.render_live_template
+      function: gramex.apps.nlg.nlgapp.render_live_template

--- a/gramex/apps/nlg/grammar.py
+++ b/gramex/apps/nlg/grammar.py
@@ -1,7 +1,7 @@
 from inflect import engine
 from tornado.template import Template
 
-from gramex.apps.nlg.utils import load_spacy_model, set_nlg_gramopt, get_lemmatizer
+from gramex.apps.nlg.nlgutils import load_spacy_model, set_nlg_gramopt, get_lemmatizer
 
 infl = engine()
 

--- a/gramex/apps/nlg/grmform.html
+++ b/gramex/apps/nlg/grmform.html
@@ -4,7 +4,7 @@
         <title>Select Dataset</title>
     </head>
     <body>
-        {% from gramex.apps.nlg.webapp import get_dataset_files, get_narrative_config_files %}
+        {% from gramex.apps.nlg.nlgapp import get_dataset_files, get_narrative_config_files %}
         {% set NLG_DATASETS = get_dataset_files(handler) %}
         {% set NLG_NARRATIVES = get_narrative_config_files(handler) %}
         <!-- Include JS dependencies  -->

--- a/gramex/apps/nlg/index.html
+++ b/gramex/apps/nlg/index.html
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-    {% from gramex.apps.nlg.webapp import read_current_config %}
+    {% from gramex.apps.nlg.nlgapp import read_current_config %}
     {% set dsid = read_current_config(handler)['dsid'] %}
     <!-- Include JS dependencies  -->
     <script src="ui/popper.js/dist/umd/popper.min.js"></script>

--- a/gramex/apps/nlg/nlgapp.py
+++ b/gramex/apps/nlg/nlgapp.py
@@ -16,7 +16,7 @@ from tornado.template import Template
 from gramex.config import variables
 from gramex.apps.nlg import grammar
 from gramex.apps.nlg import templatize
-from gramex.apps.nlg import utils
+from gramex.apps.nlg import nlgutils as utils
 
 DATAFILE_EXTS = {'.csv', '.xls', '.xlsx', '.tsv'}
 

--- a/gramex/apps/nlg/nlgsearch.py
+++ b/gramex/apps/nlg/nlgsearch.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 import six
 
-from gramex.apps.nlg import utils
+from gramex.apps.nlg import nlgutils as utils
 from gramex.apps.nlg.grammar import find_inflections
 
 SEARCH_PRIORITIES = [

--- a/gramex/apps/nlg/nlgutils.py
+++ b/gramex/apps/nlg/nlgutils.py
@@ -25,7 +25,7 @@ NP_RULES = {
 NARRATIVE_TEMPLATE = """
 {% autoescape None %}
 from nlg import grammar as G
-from nlg import utils as U
+from nlg import nlgutils as U
 from tornado.template import Template as T
 import pandas as pd
 

--- a/tests/test_nlg.py
+++ b/tests/test_nlg.py
@@ -5,7 +5,7 @@ import unittest
 import pandas as pd
 
 from gramex.apps.nlg import grammar as g
-from gramex.apps.nlg import search, utils
+from gramex.apps.nlg import nlgsearch as search, nlgutils as utils
 
 nlp = utils.load_spacy_model()
 matcher = utils.make_np_matcher(nlp)


### PR DESCRIPTION
@jaidevd Gramex adds app paths to sys.path. This means that module names like `utils` are importable via "import utils". But many apps already do this. For example, gramex/tests uses a utils.py. uat.gramener.com has a few apps that use utils.py. 

I've sent a PR that renames utils.py to nlgutils.py, and a few other modules. Is this fine? If yes, and if it doesn't break other stuff, please merge into dev.