### PR TITLE
ENH: FormHandler, cache.open support for parquet, feather

### DIFF
--- a/gramex/apps/guide/cache/README.md
+++ b/gramex/apps/guide/cache/README.md
@@ -303,8 +303,8 @@ The 2nd parameter can take the following values:
 - `gramex.cache.open(path, 'sas', ...)` loads SAS files using `pd.read_sas`
 - `gramex.cache.open(path, 'stata', ...)` loads Stata files using `pd.read_stata`
 - `gramex.cache.open(path, 'table', ...)` loads tabular text files using `pd.read_table`
-- `gramex.cache.open(path, 'parquet', ...)` loads parquet files using `pd.read_parquet`  *pyarrow or fastparquet is required*
-- `gramex.cache.open(path, 'feather', ...)` loads feather files using `pd.read_feather`  *pyarrow is required*
+- `gramex.cache.open(path, 'parquet', ...)` loads parquet files using `pd.read_parquet`. Requires [pyarrow](https://pypi.org/project/pyarrow/) or [fastparquet](https://pypi.org/project/fastparquet/)
+- `gramex.cache.open(path, 'feather', ...)` loads feather files using `pd.read_feather`. Requires [pyarrow](https://pypi.org/project/pyarrow/)
 - `gramex.cache.open(path, 'template', ...)` loads text using `tornado.template.Template`
 - `gramex.cache.open(path, 'md', ...)` loads text using `markdown.markdown`. You can use `markdown` instead of `md`
 

--- a/gramex/apps/guide/cache/README.md
+++ b/gramex/apps/guide/cache/README.md
@@ -303,6 +303,8 @@ The 2nd parameter can take the following values:
 - `gramex.cache.open(path, 'sas', ...)` loads SAS files using `pd.read_sas`
 - `gramex.cache.open(path, 'stata', ...)` loads Stata files using `pd.read_stata`
 - `gramex.cache.open(path, 'table', ...)` loads tabular text files using `pd.read_table`
+- `gramex.cache.open(path, 'parquet', ...)` loads parquet files using `pd.read_parquet`  *pyarrow or fastparquet is required*
+- `gramex.cache.open(path, 'feather', ...)` loads feather files using `pd.read_feather`  *pyarrow is required*
 - `gramex.cache.open(path, 'template', ...)` loads text using `tornado.template.Template`
 - `gramex.cache.open(path, 'md', ...)` loads text using `markdown.markdown`. You can use `markdown` instead of `md`
 

--- a/gramex/apps/guide/formhandler/README.md
+++ b/gramex/apps/guide/formhandler/README.md
@@ -37,6 +37,10 @@ You can read from multiple file formats as well as databases. The URL may be a
 
     url: /path/to/file.hdf      # Reads the dataframe at key named 'sales'
     key: sales
+
+    url: /path/to/file.parquet  # Reads the parquet file
+
+    url: /path/to/file.feather  # Reads the feather file
 ```
 
 You can read from a HTTP or HTTPS URL.

--- a/gramex/cache.py
+++ b/gramex/cache.py
@@ -159,6 +159,8 @@ _OPEN_CALLBACKS = dict(
     sas=pd.read_sas,
     stata=pd.read_stata,
     table=pd.read_table,
+    parquet=pd.read_parquet,
+    feather=pd.read_feather,
     md=_markdown,
     markdown=_markdown,
     tmpl=_template,
@@ -187,7 +189,7 @@ def open(path, callback=None, transform=None, rel=False, **kwargs):
     - ``template``: reads files using tornado.Template via io.open
     - ``markdown`` or ``md``: reads files using markdown.markdown via io.open
     - ``csv``, ``excel``, ``xls``, `xlsx``, ``hdf``, ``html``, ``sas``,
-      ``stata``, ``table``: reads using Pandas
+      ``stata``, ``table``, ``parquet``, ``feather``: reads using Pandas
     - ``xml``, ``svg``, ``rss``, ``atom``: reads using lxml.etree
 
     For example::


### PR DESCRIPTION
parquet, feather formats are useful to read processed dataframes faster.