### PR TITLE
ENH: Vega spec substitute url args #99

### DIFF
--- a/gramex/apps/guide/formhandler/README.md
+++ b/gramex/apps/guide/formhandler/README.md
@@ -379,6 +379,39 @@ $.getJSON(url)
 
 Note: For Vega-Lite, default dataset namespace is `source_0`
 
+### Parameter Substitution
+
+Vega spec can be formatted using the path arguments and URL query parameters.
+
+```yaml
+url:
+  formhandler-vega-lite-1:
+    pattern: /$YAMLURL/vega-lite-1
+    handler: FormHandler
+    kwargs:
+      url: $YAMLPATH/flags.csv
+      function: data.groupby('Continent').sum().reset_index()
+      default:
+        COL_METRIC: c1                   # COL_METRIC defaults to c1
+        COL_DIMENSION: Continent         # COL_DIMENSION defaults to Continent
+        CHART_TYPE: bar                  # CHART_TYPE defaults to bar
+      formats:
+        barchart:
+          format: vega-lite
+          spec:
+            "$schema": "https://vega.github.io/schema/vega-lite/v2.json"
+            mark: '{CHART_TYPE}'
+            encoding:
+              x: {field: '{COL_DIMENSION}', type: ordinal}     # COL_DIMENSION set to dim for ?COL_METRIC=dim
+              y: {field: '{COL_METRIC}', type: quantitative}   # COL_METRIC set to val for ?COL_METRIC=val
+```
+
+Using the above endpoint, below url draws `bar` chart with `y=c4` and `x=Continent`
+
+```html
+<script src="vega-lite-1?_format=barchart&CHART_TYPE=bar&COL_METRIC=c4"></script>
+```
+
 <div class="example">
   <a class="example-demo" href="vega-examples">FormHandler Vega Chart examples</a>
   <a class="example-src" href="vega.yaml">Source</a>

--- a/gramex/apps/guide/formhandler/vega-lite.yaml
+++ b/gramex/apps/guide/formhandler/vega-lite.yaml
@@ -6,7 +6,7 @@ url:
       url: $YAMLPATH/flags.csv
       function: data.groupby('Continent').sum().reset_index()
       default:
-        col: c1
+        COL_METRIC: c1
       formats:
         barchart:
           format: vega-lite
@@ -20,7 +20,7 @@ url:
             mark: bar
             encoding:
               x: {field: Continent, type: ordinal}
-              y: {field: c1, type: quantitative}
+              y: {field: '{COL_METRIC}', type: quantitative}
         linechart:
           format: vega-lite
           spec:
@@ -31,7 +31,7 @@ url:
             mark: line
             encoding:
               x: {field: Continent, type: ordinal}
-              y: {field: c1, type: quantitative}
+              y: {field: '{COL_METRIC}', type: quantitative}
         horizontalbarchart:
           format: vega-lite
           spec:
@@ -44,7 +44,7 @@ url:
             mark: bar
             encoding:
               y: {field: Continent, type: ordinal}
-              x: {field: c1, type: quantitative}
+              x: {field: '{COL_METRIC}', type: quantitative}
         scatterplot:
           format: vega-lite
           spec:
@@ -56,7 +56,7 @@ url:
               contains: padding
             mark: point
             encoding:
-              x: {field: c1, type: quantitative}
+              x: {field: '{COL_METRIC}', type: quantitative}
               y: {field: c2, type: quantitative}
         coloredscatterplot:
           format: vega-lite
@@ -69,7 +69,7 @@ url:
               contains: padding
             mark: point
             encoding:
-              x: {field: c1, type: quantitative}
+              x: {field: '{COL_METRIC}', type: quantitative}
               y: {field: c2, type: quantitative}
               color: {field: Continent, type: nominal}
               shape: {field: Continent, type: nominal}

--- a/gramex/apps/guide/formhandler/vega.yaml
+++ b/gramex/apps/guide/formhandler/vega.yaml
@@ -12,7 +12,7 @@ url:
       url: $YAMLPATH/flags.csv
       function: data.groupby('Continent').sum().reset_index()
       default:
-        col: c1
+        COL_METRIC: c1
       formats:
         barchart:
           format: vega
@@ -32,7 +32,7 @@ url:
                 round: true
               -
                 name: yscale
-                domain: {data: data, field: c1}
+                domain: {data: data, field: '{COL_METRIC}'}
                 nice: true
                 range: height
             axes:
@@ -46,7 +46,7 @@ url:
                   enter:
                     x: {scale: xscale, field: Continent}
                     width: {scale: xscale, band: 1}
-                    y: {scale: yscale, field: c1}
+                    y: {scale: yscale, field: '{COL_METRIC}'}
                     y2: {scale: yscale, value: 0}
         linechart:
           format: vega
@@ -66,7 +66,7 @@ url:
                 round: true
               -
                 name: yscale
-                domain: {data: data, field: c1}
+                domain: {data: data, field: '{COL_METRIC}'}
                 nice: true
                 range: height
             axes:
@@ -79,7 +79,7 @@ url:
                 encode:
                   enter:
                     x: {scale: xscale, field: Continent}
-                    y: {scale: yscale, field: c1}
+                    y: {scale: yscale, field: '{COL_METRIC}'}
         horizontalbarchart:
           format: vega
           spec:
@@ -98,7 +98,7 @@ url:
                 round: true
               -
                 name: xscale
-                domain: {data: data, field: c1}
+                domain: {data: data, field: '{COL_METRIC}'}
                 nice: true
                 range: width
             axes:
@@ -112,7 +112,7 @@ url:
                   enter:
                     y: {scale: yscale, field: Continent}
                     height: {scale: yscale, band: 1}
-                    x: {scale: xscale, field: c1}
+                    x: {scale: xscale, field: '{COL_METRIC}'}
                     x2: {scale: xscale, value: 0}
         scatterplot:
           format: vega

--- a/gramex/data.py
+++ b/gramex/data.py
@@ -890,7 +890,7 @@ def _filter_db(engine, table, meta, controls, args, source='select', id=[]):
 _VEGA_SCRIPT = os.path.join(_FOLDER, 'download.vega.js')
 
 
-def download(data, format='json', template=None, **kwargs):
+def download(data, format='json', template=None, args={}, **kwargs):
     '''
     Download a DataFrame or dict of DataFrames in various formats. This is used
     by :py:class:`gramex.handlers.FormHandler`. You are **strongly** advised to
@@ -908,6 +908,7 @@ def download(data, format='json', template=None, **kwargs):
     :arg dataset data: A DataFrame or a dict of DataFrames
     :arg str format: Output format. Can be ``csv|json|html|xlsx|template``
     :arg file template: Path to template file for ``template`` format
+    :arg dict args: dictionary of user arguments to subsitute spec
     :arg dict kwargs: Additional parameters that are passed to the relevant renderer
     :return: bytes with the download file contents
 
@@ -1049,7 +1050,7 @@ def download(data, format='json', template=None, **kwargs):
             out = out.getvalue()
             if format == 'vega':
                 out = b'[' + out + b']'
-        kwargs['spec'] = spec
+        kwargs['spec'], *_ = _replace('', args, spec)
         conf = json.dumps(kwargs, ensure_ascii=True, separators=(',', ':'), indent=None)
         conf = conf.encode('utf-8').replace(b'"__DATA__"', out)
         script = gramex.cache.open(_VEGA_SCRIPT, 'bin')

--- a/gramex/handlers/formhandler.py
+++ b/gramex/handlers/formhandler.py
@@ -168,7 +168,8 @@ class FormHandler(BaseHandler):
             result = self.modify_all(data=result, key=None, handler=self)
 
         format_options = self.set_format(opt.fmt, meta)
-        params = {k: v[0] for k, v in self.args.items() if len(v) > 0}
+        format_options['args'] = opt.args
+        params = {k: v[0] for k, v in opt.args.items() if len(v) > 0}
         for key, val in format_options.items():
             if isinstance(val, six.text_type):
                 format_options[key] = val.format(**params)

--- a/tests/test_formhandler.py
+++ b/tests/test_formhandler.py
@@ -15,6 +15,7 @@ from nose.tools import eq_, ok_
 from gramex import conf
 from gramex.http import BAD_REQUEST, FOUND
 from gramex.config import variables, objectpath, merge
+from gramex.data import _replace
 from orderedattrdict import AttrDict, DefaultAttrDict
 from pandas.util.testing import assert_frame_equal as afe
 from . import folder, TestGramex, dbutils, tempfiles
@@ -537,7 +538,7 @@ class TestFormHandler(TestGramex):
         eq_(tree.get('viewBox'), '0 0 500 300')
         # TODO: expand on test cases
         # Check spec, data for vega, vega-lite, vegam formats
-        base = '/formhandler/chart?_format={}'
+        base = '/formhandler/chart?_format={}&CHART_TYPE=bar'
         data = pd.DataFrame(self.get(base.format('json')).json())
         for fmt in {'vega', 'vega-lite', 'vegam'}:
             r = self.get(base.format(fmt))
@@ -551,6 +552,7 @@ class TestFormHandler(TestGramex):
                 df = (df[0] if isinstance(df, list) else df)['values']
             yaml_path = os.path.join(folder, '{}.yaml'.format(fmt))
             spec = gramex.cache.open(yaml_path, 'yaml')
+            spec, *_ = _replace('', {'CHART_TYPE': ['bar']}, spec)
             afe(pd.DataFrame(df), data)
             self.assertDictEqual(var, spec)
 

--- a/tests/vega-lite.yaml
+++ b/tests/vega-lite.yaml
@@ -1,7 +1,7 @@
 "$schema": "https://vega.github.io/schema/vega-lite/v2.json"
 width: 200
 height: 200
-mark: bar
+mark: '{CHART_TYPE}'
 encoding:
   x: {field: देश, type: ordinal}
   y: {field: sales, type: quantitative}

--- a/tests/vegam.yaml
+++ b/tests/vegam.yaml
@@ -1,3 +1,3 @@
 fromjson:
   - {data: __DATA__}
-  - {apply: bar, x: देश, y: sales}
+  - {apply: '{CHART_TYPE}', x: देश, y: sales}


### PR DESCRIPTION
- Supports substitution of URL args  in vega spec recursively.
- Supports default values
- `<script src="vega-lite-1?_format=barchart&CHART_TYPE=line&CHART_Y=c4"></script>` draws `line` chart with `c4` as `y` metric
- `<script src="vega-lite-1?_format=barchart"></script>` draws `bar` chart with y as `c1` 

```
url:
  formhandler-vega-lite-1:
    pattern: /$YAMLURL/vega-lite-1
    handler: FormHandler
    kwargs:
      url: $YAMLPATH/flags.csv
      function: data.groupby('Continent').sum().reset_index()
      default:
        CHART_TYPE: bar
        CHART_Y: c1
      formats:
        barchart:
          format: vega-lite
          spec:
            "$schema": "https://vega.github.io/schema/vega-lite/v2.json"
            width: 400
            height: 200
            autosize:
              type: fit
              contains: padding
            mark: '{CHART_TYPE}'
            encoding:
              x: {field: Continent, type: ordinal}
              y: {field: '{CHART_Y}', type: quantitative}
```