### PR TITLE
ENH: pptgen table column can be positional identifiers

### DIFF
--- a/gramex/pptgen/commands.py
+++ b/gramex/pptgen/commands.py
@@ -258,12 +258,19 @@ def table(shape, spec, data):
     if not len(data):
         return
     data_cols = data.columns
+    data_cols_len = len(data_cols)
     table_properties = utils.TableProperties()
     # Extending table if required.
-    table_properties.extend_table(shape, data, len(data) + 1, len(data_cols))
+    table_properties.extend_table(shape, data, len(data) + 1, data_cols_len)
     # Fetching Table Style for All Cells and texts.
     tbl_style = table_properties.get_default_css(shape)
-    styled_cols = data.columns.intersection(spec.get('columns', {}).keys() or data.columns)
+    input_colspec = spec.get('columns', {})
+    input_cols = input_colspec.keys()
+    if all(isinstance(x, int) for x in input_cols):
+        for x in list(input_cols):
+            if x < data_cols_len:
+                input_colspec[data_cols[x]] = input_colspec.pop(x)
+    styled_cols = data.columns.intersection(input_cols or data_cols)
     cell_style = table_properties.get_css(spec, styled_cols, data)
     data = data.to_dict(orient='records')
     for row_num, row in enumerate(shape.table.rows):


### PR DESCRIPTION
```
  pptxhandler/table-example2:
    pattern: /$YAMLURL/table-example2
    handler: PPTXHandler
    kwargs:
      headers:
        Content-Disposition: attachment; filename=table-example.pptx
      only: 10
      source: $YAMLPATH/examples-input.pptx  # Common example file
      data:
        table_data: {url: $YAMLPATH/sales.csv}
      new-edit-table:
        Table 1:                      # Shape Name
          table:
            data: data['table_data']
            style:                    # Common CSS for all the cells
              font-size: 14
              text-align: center
              italic: True
              underline: True
            columns:
              1:                  # Common CSS will get over-write for Sales column
                gradient: Reds
              2:
                gradient: Greens
              5:
                gradient: Blues
              0:            # Common CSS will get over-write for GrossProfit column
                bold: False
                underline: False
                italic: False
```