### PR TITLE
Make psycopg2 optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   # Install conda packages
   - conda install -y -q colorama h5py lxml matplotlib pandas pytest seaborn sqlalchemy rpy2 line_profiler tzlocal scikit-learn
   # Install pip modules
-  - pip install flake8 pep8-naming flake8-gramex flake8-blind-except flake8-print flake8-debugger bandit nose psycopg2
+  - pip install flake8 pep8-naming flake8-gramex flake8-blind-except flake8-print flake8-debugger bandit nose
   # Install node.js and packages using yarn (faster than npm)
   - npm install -g yarn
   - yarn global add eclint eslint eslint-plugin-html htmllint-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   # Install conda packages
   - conda install -y -q colorama h5py lxml matplotlib pandas pytest seaborn sqlalchemy rpy2 line_profiler tzlocal scikit-learn
   # Install pip modules
-  - pip install flake8 pep8-naming flake8-gramex flake8-blind-except flake8-print flake8-debugger bandit nose
+  - pip install flake8 pep8-naming flake8-gramex flake8-blind-except flake8-print flake8-debugger bandit nose psycopg2
   # Install node.js and packages using yarn (faster than npm)
   - npm install -g yarn
   - yarn global add eclint eslint eslint-plugin-html htmllint-cli

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requires = [
     'passlib >= 1.6.5',             # REQ: password storage (e.g. in handlers.DBAuth)
     'pathlib',                      # REQ: Manipulate paths. Part of Python 3.3+
     'pathtools >= 0.1.1',           # REQ: dependency for watchdog
-    'psycopg2 >= 2.7.1',            # OPT: PostgreSQL connections
+    # 'psycopg2 >= 2.7.1',            # OPT: PostgreSQL connections
     'psutil',                       # REQ: monitor process
     'pymysql',                      # OPT: MySQL connections
     'pytest',                       # OPT: (conda) pytest gramex plugin

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,7 @@ setup(
         'websocket-client',         # For websocket testing
         'pdfminer.six',             # For CaptureHandler testing
         'cssselect',                # For HTML testing (test_admin.py)
+        'psycopg2 >= 2.7.1'
     ],
     cmdclass={
         'develop': PostDevelopCommand,


### PR DESCRIPTION
On a clean Ubuntu 16.04 setup with nothing except miniconda, gramex
installation fails due to the missing  pg_config executable which is
required by psycopg2