### PR TITLE
pre-commit configuration in gramex init

### DIFF
--- a/gramex/apps/init/.pre-commit-config.yaml
+++ b/gramex/apps/init/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.0.0
+  hooks:
+  - id: trailing-whitespace
+    description: This hook trims trailing whitespace.
+  - id: end-of-file-fixer
+    description: Ensures that a file is either empty or ends with one newline.
+  - id: check-yaml
+    description: This hook checks yaml files for parseable syntax.
+  - id: check-added-large-files
+    description: Prevent giant files from being committed. Defaults to 500kB.
+  - id: pretty-format-json
+    description: This hook sets a standard for formatting JSON files.
+    args: [--indent=2, --no-sort-keys]
+  - id: flake8
+    description: This hook runs flake8.
+

--- a/gramex/apps/init/setup.sh
+++ b/gramex/apps/init/setup.sh
@@ -1,0 +1,7 @@
+
+# installs pre-commit package for build errors checks
+pip install pre-commit
+# configures pre-commit hook in target_directory/.git/hooks/
+pre-commit install
+# after above step, a pre-commit file will be created in target_directory/.git/hooks/
+


### PR DESCRIPTION
This PR Introduces configuration for build error checks locally using `pre-commit` python package.

-  `pre-commit` is triggered on every `git commit` by default
- these checks are configured in `.pre-commit-config.yaml`: trailing whitespace, ending a file with single empty line, ensures larger than 500KB files aren't committed, valid YAML config, python checks via `flake8`, `JSON` checks 

# Test
- create a new directory
- run `gramex init` on terminal (*nix-based systems) or on `git bash` (Windows)

## Test Output

![image](https://user-images.githubusercontent.com/1143687/65369659-7db3eb80-dc6d-11e9-9f3e-96d342b67b56.png)

# Test in an existing live application
- Change a file (introduce a bug: for example, add a `console` statement in JS file) and run: `git commit`. Commit should fail. Fix the bug and re-commit. Commit should succeed.

