### PR TITLE
WIP: Fast test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,10 @@ install:
   - hash -r
   # Install conda packages
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -y -q colorama h5py lxml matplotlib pandas pytest seaborn sqlalchemy line_profiler tzlocal scikit-learn
+  # For the NumPy version below, see: https://bitbucket.org/rpy2/rpy2/issues/572
+  # Newer versions of NumPy require newer versions of rpy2. The latter are not available on conda.
+  - conda install -y -q colorama h5py lxml matplotlib pandas pytest seaborn sqlalchemy line_profiler tzlocal scikit-learn rpy2 numpy=1.16
   # rpy2 v2.9.6 is compatible with pandas 1.0, not available on the default channel
-  - conda install -c conda-forge rpy2
   # Install node.js
   - nvm install 12
   # Set up variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ script:
   - gramex license accept
   - gramex setup --all  # ensure node-sass, puppetter exists
   - export NOSE_WITH_COVERAGE=1
+  - export NOSE_WITH_TIMER=1
   - make test
 
   # Test specific apps

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ script:
   - pip install gramexenterprise
   - gramex license accept
   - gramex setup --all  # ensure node-sass, puppetter exists
+  - export NOSE_WITH_COVERAGE=1
   - make test
 
   # Test specific apps

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,15 @@ lint:
 	# htmllint: ignore test coverage, node_modules, Sphinx doc _builds
 	find . -name '*.html' | grep -v htmlcov | grep -v node_modules | grep -v _build | xargs htmllint
 	# Run Python flake8 and bandit security checks
-	command -v flake8 2>/dev/null 2>&1 || pip install flake8 pep8-naming flake8-gramex flake8-blind-except flake8-print flake8-debugger
+	command -v flake8 2>/dev/null 2>&1 || $(PYTHON) -m pip install flake8 pep8-naming flake8-gramex flake8-blind-except flake8-print flake8-debugger
 	flake8 gramex testlib tests
-	command -v bandit 2>/dev/null 2>&1 || pip install bandit
+	command -v bandit 2>/dev/null 2>&1 || $(PYTHON) -m pip install bandit
 	bandit gramex --recursive --format csv || true    # Just run bandit as a warning
 
-test:
-	pip install nose
+test-setup:
+	$(PYTHON) -m pip install -r tests/requirements.txt
+
+test: test-setup
 	$(PYTHON) setup.py nosetests
 
 release-test: clean-test lint docs test

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ per-file-ignores =
 [nosetests]
 verbosity=2
 nocapture=1
-with-coverage=1
+; with-coverage=1
 cover-package=gramex
 cover-erase=1
 cover-html=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,13 @@ per-file-ignores =
 [nosetests]
 verbosity=2
 nocapture=1
+# Enable coverage via environment NOSE_WITH_COVERAGE=1
 ; with-coverage=1
 cover-package=gramex
 cover-erase=1
 cover-html=1
 cover-html-dir=htmlcov
 cover-branches=1
-; TODO: this doesn't work unless nose-timer is installed
+# Enable timer via environment NOSE_WITH_TIMER=1
 ; with-timer=1
-; timer-top-n=5
+timer-top-n=5

--- a/setup.py
+++ b/setup.py
@@ -146,17 +146,7 @@ setup(
         'pytest11': ['gramextest = gramex.gramextest']
     },
     test_suite='tests',
-    tests_require=[
-        'nose',
-        'nose-timer',
-        'coverage',
-        'python-dateutil',          # For schedule testing
-        'testfixtures',             # For logcapture
-        'sphinx_rtd_theme',         # For documentation
-        'websocket-client',         # For websocket testing
-        'pdfminer.six',             # For CaptureHandler testing
-        'cssselect',                # For HTML testing (test_admin.py)
-        'psycopg2 >= 2.7.1'         # OPT: PostgreSQL connections
-    ],
+    # Install test libraries via `make test-setup` -> tests/requirements.txt.
+    # Use this instead of tests_require because nose plugins are installed this way.
     **release_args
 )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ install_requires = [
     'lxml',                         # OPT: (conda) gramex.pptgen
     'markdown',                     # OPT: transforms, gramex.services.create_alert()
     'matplotlib',                   # OPT: (conda) gramex.data.download()
+    'numpy == 1.16',
     'oauthlib >= 1.1.2',            # SRV: OAuth request-signing
     'orderedattrdict >= 1.6.0',     # REQ: OrderedDict with attr access for configs
     'pandas == 0.25.3',             # REQ: (conda) gramex.data.filter()

--- a/testlib/test_pptgen.py
+++ b/testlib/test_pptgen.py
@@ -243,7 +243,7 @@ class TestPPTGen(TestCase):
 
     def test_group_and_image(self):
         # Test case for group objects.
-        for img in [self.image, 'https://learn.gramener.com/guide/pptxhandler/sample.png']:
+        for img in [self.image, 'https://learn.gramener.com/guide/pptxhandler/v1/sample.png']:
             try:
                 target = pptgen.pptgen(
                     source=self.input,

--- a/testlib/test_r.py
+++ b/testlib/test_r.py
@@ -17,9 +17,9 @@ def test_init():
             import rpy2.robjects  # NOQA: F401
     # But Gramex uses Conda PATH
     r('ls()')
-    from rpy2.rinterface_lib import openrlib
+    import rpy2.rinterface
     # Note: in your machine, ensure "conda" is part of your Anaconda PATH
-    ok_('conda' in openrlib.R_HOME)
+    ok_('conda' in rpy2.rinterface.R_HOME)
 
 
 def test_command():

--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -70,6 +70,25 @@ url:
   pathnorm1: {pattern: "/./path/norm1", handler: FunctionHandler, kwargs: {function: str("/path/norm1") }}
   pathnorm2: {pattern: "/path/./norm2", handler: FunctionHandler, kwargs: {function: str("/path/norm2") }}
 
+  # TestSchedule
+  schedule-key:
+    pattern: /schedule-key
+    handler: FunctionHandler
+    kwargs:
+      function: utils.schedule_key()
+
+  slow-count-start:
+    pattern: /slow-count-start
+    handler: FunctionHandler
+    kwargs:
+      function: utils.slow_count_start()
+
+  slow-count-check:
+    pattern: /slow-count-check
+    handler: FunctionHandler
+    kwargs:
+      function: utils.slow_count_check()
+
   # test_handlers
   base:
     pattern: /base
@@ -1900,16 +1919,13 @@ watch:
     on_modified: nonexistent            # This should not throw an error, only report a warning
 
 schedule:
-  schedule-startup-set-key:
-    function: utils.slow_count          # Set global value schedule-key to 1
-    args: ['schedule-key', 1]
+  schedule-start:
+    function: utils.schedule_start
     startup: true
-  schedule-startup-slow:
+  schedule-slow-count:
     function: utils.slow_count          # Set global schedule-count every 10ms
-    args: 'schedule-count'
-    kwargs: {count: 1000}
-    startup: true
     thread: true
+    startup: true
   schedule-timed:
     function: gramex.config.app_log('schedule-timed ran now')
     hours: 5

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,13 @@
+# Base testing packages
+nose
+nose-timer
+coverage
+
+# Support modules for testing
+python-dateutil       # For schedule testing
+testfixtures          # For logcapture
+sphinx_rtd_theme      # For documentation
+websocket-client      # For websocket testing
+pdfminer.six          # For CaptureHandler testing
+cssselect             # For HTML testing (test_admin.py)
+psycopg2 >= 2.7.1     # OPT: PostgreSQL connections

--- a/tests/test_filehandler.py
+++ b/tests/test_filehandler.py
@@ -9,7 +9,6 @@ from gramex.http import OK, FORBIDDEN, METHOD_NOT_ALLOWED
 from orderedattrdict import AttrDict
 from gramex.ml import r
 from gramex.transforms import badgerfish, rmarkdown
-from nose.plugins.skip import SkipTest
 from . import server, tempfiles, TestGramex, folder
 
 
@@ -148,8 +147,6 @@ class TestFileHandler(TestGramex):
             self.check('/dir/transform/markdown.md', text=markdown.markdown(f.read()))
 
     def test_rmarkdown(self):
-        if os.environ.get('BRANCH', '') not in {'dev', 'master'}:
-            raise SkipTest('Install slow rmarkdown installation only on dev/master')
         # install rmarkdown if missing
         r('''
             packages <- c('rmarkdown')

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,32 @@
+from . import TestGramex
+from datetime import datetime
+from dateutil.tz import tzlocal, tzutc
+from gramex.http import OK
+from gramex.services import info
+from nose.tools import eq_, ok_
+
+
+class TestSchedule(TestGramex):
+    def test_startup(self):
+        # Check if code in schedules with startup: true are executed
+        self.check('/schedule-key', text='1', code=OK)
+
+    def test_long_running_threads(self):
+        # Start utils.slow_count in a thread and wait till the scheduler starts.
+        # It increases info['schedule-count'] every 10ms.
+        self.check('/slow-count-start', code=OK)
+        # Check that the counter has increased after a small delay
+        self.check('/slow-count-check', code=OK)
+
+    def test_timed_schedule(self):
+        # TODO: This test only works when we run at 5 am in the server's time zone. Not robust
+        # Check that schedules are present and created
+        ok_('schedule-timed' in info.schedule)
+        ok_('schedule-timed-utc' in info.schedule)
+        # Check that the schedules will run at 5 am in the appropriate time zone
+        for key, tz in (('schedule-timed', tzlocal()), ('schedule-timed-utc',
+                                                        tzutc())):
+            t = datetime.fromtimestamp(info.schedule[key].next, tz)
+            eq_(t.hour, 5)
+            # Ideally, this should be 0, but there may be a short delay
+            ok_(t.minute < 2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ from gramex.handlers import BaseHandler
 watch_info = []
 ws_info = []
 counters = Counter()
-slow = {'value': 0, 'started': False, 'max': 10}
+slow = {'value': 0, 'started': False, 'max': 20}
 
 
 def args_as_json(handler):
@@ -169,7 +169,8 @@ def slow_count_start():
 
 def slow_count_check(delay=0.01):
     time.sleep(delay)
-    assert slow['start'] < slow['value'] < slow['max'] - 1, 'Schedule runs in parallel'
+    assert slow['start'] < slow['value'], 'Schedule already started'
+    assert slow['value'] < slow['max'] - 1, 'Schedule runs in parallel'
 
 
 def slow_count(delay=0.01):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,6 +21,7 @@ from gramex.handlers import BaseHandler
 watch_info = []
 ws_info = []
 counters = Counter()
+slow = {'value': 0, 'started': False, 'max': 10}
 
 
 def args_as_json(handler):
@@ -153,9 +154,30 @@ def on_deleted(event):
     watch_info.append({'event': event, 'type': 'deleted'})
 
 
-def slow_count(var, count=1, delay=0.01):
-    for x in range(count):
-        info[var] = x
+def schedule_start():
+    counters['schedule-key'] += 1
+
+
+def schedule_key():
+    return '%d' % counters['schedule-key']
+
+
+def slow_count_start():
+    slow['started'] = True
+    slow['start'] = slow['value']
+
+
+def slow_count_check(delay=0.01):
+    time.sleep(delay)
+    assert slow['start'] < slow['value'] < slow['max'] - 1, 'Schedule runs in parallel'
+
+
+def slow_count(delay=0.01):
+    # This runs in a thread and increments slow['value'] every 10ms
+    while not slow['started']:
+        time.sleep(delay)
+    for x in range(slow['max']):
+        slow['value'] = x
         time.sleep(delay)
 
 


### PR DESCRIPTION
I've made the following changes:

1. When Gramex ran any test, it used to run a brittle TestSchedule that assumed that Gramex would start in 10 seconds, and ensured that nosetests runs for at least 10 seconds. This is refactored. **BENEFIT**: `nosetests test.test_functionhandler` and similar sub-tests run quicker
2. I've replaced `tests_require` with `tests/requirements.txt`. The former doesn't accept nose plugins. So now, we run `make test-setup` or `pip install -r tests/requirements.txt` before any tests