### PR TITLE
ENH: Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is something not working as expected?**
+Please edit this line and tell us what's not working.
+
+**Steps to reproduce.**
+Please help us reproduce the bug, by sharing:
+1. your Gramex configuration,
+2. the Python, HTML or JavaScript code that connects to the
+   configuration
+3. the Gramex log output, or browser console errors (if any)
+4. a screenshot of the problem,
+
+
+**Expected behavior**
+Please tell us what should have happened?
+
+**Your environment:**
+ - OS: [e.g. Linux, OSX, Windows]
+ - Browser [Chrome, Firefox, Safari, IE, etc.]
+ - Python version: []
+ - Gramex version: []
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -6,7 +6,8 @@ Please summarize the commits from the source branch.
 
 
 **Checklist**
-  - [ ] Target branch is `"master"`
-  - [ ] All relevant tests passing.
-  - [ ] Inlcude screenshots or any other output which shows what this PR does.
+  - [ ] Is the target branch `"master"`?
+  - [ ] Are all relevant tests passing?
   - [ ] Does this PR have an assignee? Has a review been requested?
+  - [ ] Have you included all information that reviewers might need to reproduce
+    this contribution?

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,12 @@
+**Which issue (if any) does this PR fix?**
+Fixes #
+
+**Commit Summary**
+Please summarize the commits from the source branch.
+
+
+**Checklist**
+  - [ ] Target branch is `"master"`
+  - [ ] All relevant tests passing.
+  - [ ] Inlcude screenshots or any other output which shows what this PR does.
+  - [ ] Does this PR have an assignee? Has a review been requested?


### PR DESCRIPTION
Users can choose three templates for submitting issues - bug reports,
feature requests, and a blank one. They contain checklists to ensure
reproducibility. The PR template contains a checklist
for users to ensure that patches can be reproduced and reviewed easily.