### PR TITLE
Allow ModelHandler URLs to be relative to YAMLPATH

### DIFF
--- a/gramex/handlers/modelhandler.py
+++ b/gramex/handlers/modelhandler.py
@@ -36,7 +36,7 @@ class ModelHandler(BaseHandler):
             self.request_body.update(self.args)
         url = self.request_body.get('url', '')
         if url and gramex.data.get_engine(url) == 'file':
-            self.request_body['url'] = os.path.join(self.path, os.path.split(url)[-1])
+            self.request_body['url'] = url
 
     def get_data_flag(self):
         '''

--- a/gramex/ml.py
+++ b/gramex/ml.py
@@ -8,6 +8,7 @@ import pandas as pd
 from tornado.gen import coroutine, Return, sleep
 from tornado.httpclient import AsyncHTTPClient
 from gramex.config import locate, app_log, merge, variables
+from gramex.install import _mkdir
 
 # Expose joblob.load via gramex.ml
 load = joblib.load                      # noqa
@@ -101,6 +102,7 @@ class Classifier(object):
         '''
         Serializes the model and associated parameters
         '''
+        _mkdir(os.path.dirname(path))
         joblib.dump(self, path, compress=9)
 
 


### PR DESCRIPTION
`ModelHandler.path` is the path to the model - and should have nothing to do with the URL / path to the training dataset. Currently, we assume that models and data are in the same directory. This PR stops assuming that the training dataset URLs are relative to the `path`
kwarg of ModelHandler. Instead, makes them relative to $YAMLPATH.

