### PR TITLE
FIX: Viewing an MLHandler template drops the target col

### DIFF
--- a/gramex/handlers/mlhandler.py
+++ b/gramex/handlers/mlhandler.py
@@ -270,9 +270,11 @@ class MLHandler(FormHandler):
         return data
 
     @classmethod
-    def _get_pipeline(cls, data):
-        if op.exists(cls.model_path):
-            return joblib.load(cls.model_path)
+    def _get_pipeline(cls, data, force=False):
+        if not force:
+            if op.exists(cls.model_path):
+                return joblib.load(cls.model_path)
+        # Else assemble the model anyway
         if data is not None:
             if not len(data):
                 return None
@@ -466,6 +468,7 @@ class MLHandler(FormHandler):
                 to_predict = data.drop([target_col], axis=1)
             else:
                 target = None
+                to_predict = data
             if action in ('predict', 'score'):
                 prediction = yield gramex.service.threadpool.submit(
                     # self._predict, data, transform=False)
@@ -551,8 +554,7 @@ class MLHandler(FormHandler):
 
             # assemble the pipeline
             if self.get_opt('pipeline', True):
-                # self.model = self._get_pipeline(data, target_col=target_col, **opts)
-                self.model = self._get_pipeline(data)
+                self.model = self._get_pipeline(data, force=True)
             # train the model
             target = data[target_col]
             train = data[[c for c in data if c != target_col]]

--- a/gramex/handlers/mlhandler.py
+++ b/gramex/handlers/mlhandler.py
@@ -462,13 +462,14 @@ class MLHandler(FormHandler):
                 data = self.load_data()
             target_col = self.get_opt('target_col')
             if target_col in data:
-                target = data.pop(target_col)
+                target = data[target_col]
+                to_predict = data.drop([target_col], axis=1)
             else:
                 target = None
             if action in ('predict', 'score'):
                 prediction = yield gramex.service.threadpool.submit(
                     # self._predict, data, transform=False)
-                    self._predict, data)
+                    self._predict, to_predict)
                 if action == 'predict':
                     self.write(_serialize_prediction(prediction))
                 elif action == 'score':

--- a/gramex/handlers/mlhandler.py
+++ b/gramex/handlers/mlhandler.py
@@ -339,10 +339,7 @@ class MLHandler(FormHandler):
             target = data[score_col]
             data = data.drop([score_col], axis=1)
             return self.model.score(data, target)
-        prediction = self.model.predict(data)
-        # Write prediction into the target col. If target_col
-        target_col = self.get_opt('target_col')
-        data[_prediction_col if target_col in data else target_col] = prediction
+        data[self.get_opt('target_col', _prediction_col)] = self.model.predict(data)
         return data
 
     def _parse_data(self, _cache=True):
@@ -470,10 +467,7 @@ class MLHandler(FormHandler):
                 if action == 'predict':
                     self.write(json.dumps(prediction, indent=4, cls=CustomJSONEncoder))
                 elif action == 'score':
-                    if _prediction_col in prediction:
-                        prediction = prediction[_prediction_col]
-                    else:
-                        prediction = prediction[target_col]
+                    prediction = prediction[target_col if target_col else _prediction_col]
                     score = accuracy_score(target.astype(prediction.dtype),
                                            prediction)
                     self.write(json.dumps({'score': score}, indent=4))

--- a/tests/test_mlhandler.py
+++ b/tests/test_mlhandler.py
@@ -43,104 +43,6 @@ class TestMLHandler(TestGramex):
         for p in paths:
             tempfiles[p] = p
 
-    def test_default(self):
-        # Check if model has been trained on iris, and exists at the right path.
-        clf = joblib.load(op.join(folder, 'model.pkl'))
-        self.assertIsInstance(clf, Pipeline)
-        self.assertIsInstance(clf.named_steps['transform'], ColumnTransformer)
-        self.assertIsInstance(clf.named_steps['LogisticRegression'], LogisticRegression)
-        score = clf.score(self.df[[c for c in self.df if c != 'species']], self.df['species'])
-        self.assertGreaterEqual(score, self.ACC_TOL)
-
-    def test_get_predictions(self):
-        resp = self.get(
-            '/mlhandler?sepal_length=5.9&sepal_width=3&petal_length=5.1&petal_width=1.8')
-        self.assertEqual(resp.json(), ['virginica'])
-        req = '/mlhandler?'
-        samples = []
-        target = []
-        for row in self.df.sample(n=5).to_dict(orient='records'):
-            samples.extend([(col, value) for col, value in row.items() if col != 'species'])
-            target.append(row['species'])
-        params = '&'.join([f'{k}={v}' for k, v in samples])
-        resp = self.get(req + params)
-        self.assertGreaterEqual(accuracy_score(resp.json(), target), 0.8)  # NOQA: E912
-
-    def test_get_score(self):
-        req = '/mlhandler?_action=score&'
-        samples = []
-        for row in self.df.sample(n=5).to_dict(orient='records'):
-            samples.extend([(col, value) for col, value in row.items()])
-        params = '&'.join([f'{k}={v}' for k, v in samples])
-        resp = self.get(req + params)
-        self.assertGreaterEqual(resp.json()['score'], 0.6)  # NOQA: E912
-
-    def test_download(self):
-        r = self.get('/mlhandler?_download')
-        buff = BytesIO(r.content)
-        buff.seek(0)
-        clf = joblib.load(buff)
-        self.assertIsInstance(clf, Pipeline)
-        self.assertIsInstance(clf.named_steps['transform'], ColumnTransformer)
-        self.assertIsInstance(clf.named_steps['LogisticRegression'], LogisticRegression)
-
-    def test_get_model_params(self):
-        params = self.get('/mlhandler?_model').json()
-        self.assertDictEqual(LogisticRegression().get_params(), params)
-
-    def test_get_bulk_predictions(self):
-        df = self.df.drop_duplicates()
-        target = df.pop('species')
-        resp = self.get('/mlhandler', method='post', data=df.to_json(orient='records'),
-                        headers={'Content-Type': 'application/json'})
-        self.assertGreaterEqual(accuracy_score(target, resp.json()), self.ACC_TOL)
-
-    def test_get_predictions_post_file(self):
-        df = self.df.drop_duplicates()
-        target = df.pop('species')
-        buff = StringIO()
-        df.to_csv(buff, index=False, encoding='utf8')
-        buff.seek(0)
-        resp = self.get('/mlhandler?_action=predict',
-                        method='post', files={'file': ('iris.csv', buff)})
-        self.assertGreaterEqual(accuracy_score(target, resp.json()), self.ACC_TOL)
-
-    def test_get_bulk_score(self):
-        resp = self.get(
-            '/mlhandler?_action=score', method='post',
-            data=self.df.to_json(orient='records'),
-            headers={'Content-Type': 'application/json'})
-        self.assertGreaterEqual(resp.json()['score'], self.ACC_TOL)
-
-    def test_train(self):
-        # backup the original model
-        clf = joblib.load(op.join(folder, 'model.pkl'))
-        X, y = make_classification()  # NOQA: N806
-        xtrain, xtest, ytrain, ytest = train_test_split(X, y, stratify=y, test_size=0.25)
-        df = pd.DataFrame(xtrain)
-        df['target'] = ytrain
-        try:
-            resp = self.get('/mlhandler?_action=train&target_col=target', method='post',
-                            data=df.to_json(orient='records'),
-                            headers={'Content-Type': 'application/json'})
-            self.assertGreaterEqual(resp.json()['score'], 0.8)  # NOQA: E912
-        finally:
-            joblib.dump(clf, op.join(folder, 'model.pkl'))
-
-    def test_get_cache(self):
-        df = pd.DataFrame.from_records(self.get('/mlhandler?_cache=true').json())
-        pd.testing.assert_frame_equal(df, self.df)
-
-    def test_clear_cache(self):
-        try:
-            r = self.get('/mlhandler?_cache', method='delete')
-            self.assertEqual(r.status_code, OK)
-            self.assertListEqual(self.get('/mlhandler?_cache').json(), [])
-        finally:
-            self.get('/mlhandler?_action=append', method='post',
-                     data=self.df.to_json(orient='records'),
-                     headers={'Content-Type': 'application/json'})
-
     def test_append(self):
         try:
             r = self.get('/mlhandler?_action=append', method='post',
@@ -155,37 +57,72 @@ class TestMLHandler(TestGramex):
                      data=self.df.to_json(orient='records'),
                      headers={'Content-Type': 'application/json'})
 
-    def test_retrain(self):
-        # Make some data
-        x, y = make_classification()
-        xtrain, xtest, ytrain, ytest = train_test_split(x, y, stratify=y, test_size=0.25)
-        df = pd.DataFrame(xtrain)
-        df['target'] = ytrain
-        test_df = pd.DataFrame(xtest)
-        test_df['target'] = ytest
-        try:
-            # clear the cache
-            resp = self.get('/mlhandler?_cache', method='delete')
-            self.assertEqual(resp.status_code, OK)
-            resp = self.get('/mlhandler?_cache')
-            self.assertListEqual(resp.json(), [])
-            # append new data, don't train
-            self.get('/mlhandler?_action=append', method='post', data=df.to_json(orient='records'),
-                     headers={'Content-Type': 'application/json'})
-            # now, retrain
-            self.get('/mlhandler?_action=retrain&target_col=target', method='post')
-            # Check score against test dataset
-            resp = self.get(
-                '/mlhandler?_action=score', method='post',
-                data=test_df.to_json(orient='records'),
-                headers={'Content-Type': 'application/json'})
-            self.assertGreaterEqual(resp.json()['score'], 0.6)  # NOQA: E912
-        finally:
-            # revert to the original cache
-            self.get('/mlhandler?_cache', method='delete')
-            self.get('/mlhandler?_action=append', method='post',
-                     data=self.df.to_json(orient='records'),
-                     headers={'Content-Type': 'application/json'})
+    def test_append_train(self):
+        df_train = self.df[self.df['species'] != 'virginica']
+        df_append = self.df[self.df['species'] == 'virginica']
+
+        resp = self.get('/mlincr?_model&class=LogisticRegression&target_col=species', method='put')
+        self.assertEqual(resp.status_code, OK)
+
+        resp = self.get(
+            '/mlincr?_action=append&_action=train', method='post',
+            data=df_train.to_json(orient='records'),
+            headers={'Content-Type': 'application/json'})
+        self.assertEqual(resp.status_code, OK)
+
+        resp = self.get(
+            '/mlincr?_action=score', method='post',
+            data=self.df.to_json(orient='records'),
+            headers={'Content-Type': 'application/json'})
+        org_score = resp.json()['score']
+
+        resp = self.get(
+            '/mlincr?_action=append&_action=train', method='post',
+            data=df_append.to_json(orient='records'),
+            headers={'Content-Type': 'application/json'})
+        self.assertEqual(resp.status_code, OK)
+        resp = self.get(
+            '/mlincr?_action=score', method='post',
+            data=self.df.to_json(orient='records'),
+            headers={'Content-Type': 'application/json'})
+        new_score = resp.json()['score']
+        # Score should improve by at least 30%
+        self.assertGreaterEqual(new_score - org_score, 0.3)  # NOQA: E912
+
+    def test_blank_slate(self):
+        # Assert that a model doesn't have to exist
+        model_path = op.join(variables['GRAMEXDATA'], 'apps', 'mlhandler', 'mlhandler-blank.pkl')
+        self.assertFalse(op.exists(model_path))
+        r = self.get('/mlblank?sepal_length=5.9&sepal_width=3&petal_length=5.1&petal_width=1.8')
+        self.assertEqual(r.status_code, NOT_FOUND)
+        # Post options in any order, randomly
+        r = self.get('/mlblank?_model&target_col=species', method='put')
+        self.assertEqual(r.status_code, OK)
+        r = self.get('/mlblank?_model&exclude=petal_width', method='put')
+        self.assertEqual(r.status_code, OK)
+        r = self.get('/mlblank?_model&nums=sepal_length&nums=sepal_width&nums=petal_length',
+                     method='put')
+        self.assertEqual(r.status_code, OK)
+
+        r = self.get('/mlblank?_model&class=LogisticRegression', method='put')
+        self.assertEqual(r.status_code, OK)
+
+        # check the training opts
+        self.assertDictEqual(
+            self.get('/mlblank?_cache&_opts').json(),
+            {
+                'target_col': 'species',
+                'exclude': ['petal_width'],
+                'nums': ['sepal_length', 'sepal_width', 'petal_length']
+            }
+        )
+        self.assertDictEqual(
+            self.get('/mlblank?_cache&_params').json(),
+            {
+                'class': 'LogisticRegression',
+                'params': {}
+            }
+        )
 
     def test_change_model(self):
         # back up the original model
@@ -219,6 +156,25 @@ class TestMLHandler(TestGramex):
             # restore the backup
             joblib.dump(clf, op.join(folder, 'model.pkl'))
 
+    def test_clear_cache(self):
+        try:
+            r = self.get('/mlhandler?_cache', method='delete')
+            self.assertEqual(r.status_code, OK)
+            self.assertListEqual(self.get('/mlhandler?_cache').json(), [])
+        finally:
+            self.get('/mlhandler?_action=append', method='post',
+                     data=self.df.to_json(orient='records'),
+                     headers={'Content-Type': 'application/json'})
+
+    def test_default(self):
+        # Check if model has been trained on iris, and exists at the right path.
+        clf = joblib.load(op.join(folder, 'model.pkl'))
+        self.assertIsInstance(clf, Pipeline)
+        self.assertIsInstance(clf.named_steps['transform'], ColumnTransformer)
+        self.assertIsInstance(clf.named_steps['LogisticRegression'], LogisticRegression)
+        score = clf.score(self.df[[c for c in self.df if c != 'species']], self.df['species'])
+        self.assertGreaterEqual(score, self.ACC_TOL)
+
     def test_delete(self):
         clf = joblib.load(op.join(folder, 'model.pkl'))
         try:
@@ -231,144 +187,14 @@ class TestMLHandler(TestGramex):
         finally:
             joblib.dump(clf, op.join(folder, 'model.pkl'))
 
-    def test_model_default_path(self):
-        clf = joblib.load(op.join(
-            gramex.config.variables['GRAMEXDATA'], 'apps', 'mlhandler', 'mlhandler-nopath.pkl'))
+    def test_download(self):
+        r = self.get('/mlhandler?_download')
+        buff = BytesIO(r.content)
+        buff.seek(0)
+        clf = joblib.load(buff)
         self.assertIsInstance(clf, Pipeline)
         self.assertIsInstance(clf.named_steps['transform'], ColumnTransformer)
         self.assertIsInstance(clf.named_steps['LogisticRegression'], LogisticRegression)
-        resp = self.get(
-            '/mlnopath?_action=score', method='post',
-            headers={'Content-Type': 'application/json'})
-        self.assertGreaterEqual(resp.json()['score'], self.ACC_TOL)
-
-    def test_post_after_delete_default_model(self):
-        clf = joblib.load(op.join(folder, 'model.pkl'))
-        try:
-            r = self.get('/mlhandler?_model', method='delete')
-            self.assertEqual(r.status_code, OK)
-            self.assertFalse(op.exists(op.join(folder, 'model.pkl')))
-            # recreate the model
-            X, y = make_classification()  # NOQA: N806
-            xtrain, xtest, ytrain, ytest = train_test_split(X, y, stratify=y, test_size=0.25)
-            df = pd.DataFrame(xtrain)
-            df['target'] = ytrain
-            r = self.get('/mlhandler?_action=train&target_col=target', method='post',
-                         data=df.to_json(orient='records'),
-                         headers={'Content-Type': 'application/json'})
-            self.assertEqual(r.status_code, OK)
-            self.assertGreaterEqual(r.json()['score'], 0.8)  # NOQA: E912
-        finally:
-            joblib.dump(clf, op.join(folder, 'model.pkl'))
-
-    def test_post_after_delete_custom_model(self):
-        clf = joblib.load(op.join(folder, 'model.pkl'))
-        try:
-            r = self.get('/mlhandler?_model', method='delete')
-            self.assertEqual(r.status_code, OK)
-            self.assertFalse(op.exists(op.join(folder, 'model.pkl')))
-            # recreate the model
-            X, y = make_classification()  # NOQA: N806
-            xtrain, xtest, ytrain, ytest = train_test_split(X, y, stratify=y, test_size=0.25)
-            df = pd.DataFrame(xtrain)
-            df['target'] = ytrain
-            r = self.get('/mlhandler?_model&class=GaussianNB', method='put')
-            self.assertEqual(r.status_code, OK)
-            r = self.get('/mlhandler?_action=train&target_col=target', method='post',
-                         data=df.to_json(orient='records'),
-                         headers={'Content-Type': 'application/json'})
-            self.assertEqual(r.status_code, OK)
-            self.assertGreaterEqual(r.json()['score'], 0.8)  # NOQA: E912
-            clf = joblib.load(op.join(folder, 'model.pkl'))
-            self.assertIsInstance(clf.named_steps['GaussianNB'], GaussianNB)
-        finally:
-            joblib.dump(clf, op.join(folder, 'model.pkl'))
-
-    def test_blank_slate(self):
-        # Assert that a model doesn't have to exist
-        model_path = op.join(variables['GRAMEXDATA'], 'apps', 'mlhandler', 'mlhandler-blank.pkl')
-        self.assertFalse(op.exists(model_path))
-        r = self.get('/mlblank?sepal_length=5.9&sepal_width=3&petal_length=5.1&petal_width=1.8')
-        self.assertEqual(r.status_code, NOT_FOUND)
-
-        # Post options in any order, randomly
-        r = self.get('/mlblank?_model&target_col=species', method='put')
-        self.assertEqual(r.status_code, OK)
-        r = self.get('/mlblank?_model&exclude=petal_width', method='put')
-        self.assertEqual(r.status_code, OK)
-        r = self.get('/mlblank?_model&nums=sepal_length&nums=sepal_width&nums=petal_length',
-                     method='put')
-        self.assertEqual(r.status_code, OK)
-
-        r = self.get('/mlblank?_model&class=LogisticRegression', method='put')
-        self.assertEqual(r.status_code, OK)
-
-        # check the training opts
-        self.assertDictEqual(
-            self.get('/mlblank?_cache&_opts').json(),
-            {
-                'target_col': 'species',
-                'exclude': ['petal_width'],
-                'nums': ['sepal_length', 'sepal_width', 'petal_length']
-            }
-        )
-        self.assertDictEqual(
-            self.get('/mlblank?_cache&_params').json(),
-            {
-                'class': 'LogisticRegression',
-                'params': {}
-            }
-        )
-
-    def test_single_line_train_fetch_model(self):
-        resp = self.get('/mlblank?_model&class=DecisionTreeClassifier&target_col=species',
-                        method='put')
-        self.assertEqual(resp.status_code, OK)
-        # train
-        line = StringIO()
-        self.df.head(1).to_csv(line, index=False, encoding='utf8')
-        line.seek(0)
-        resp = self.get('/mlblank?_action=train', method='post',
-                        files={'file': ('iris.csv', line.read())})
-        self.assertEqual(resp.status_code, OK)
-        self.assertGreaterEqual(resp.json()['score'], 0.0)
-
-        # get the model
-        resp = self.get('/mlblank')
-        self.assertEqual(resp.status_code, OK)
-
-    def test_append_train(self):
-        df_train = self.df[self.df['species'] != 'virginica']
-        df_append = self.df[self.df['species'] == 'virginica']
-
-        resp = self.get('/mlincr?_model&class=LogisticRegression&target_col=species', method='put')
-        self.assertEqual(resp.status_code, OK)
-
-        resp = self.get(
-            '/mlincr?_action=append&_action=train', method='post',
-            data=df_train.to_json(orient='records'),
-            headers={'Content-Type': 'application/json'})
-        self.assertEqual(resp.status_code, OK)
-
-        resp = self.get(
-            '/mlincr?_action=score', method='post',
-            data=self.df.to_json(orient='records'),
-            headers={'Content-Type': 'application/json'})
-        org_score = resp.json()['score']
-
-        resp = self.get(
-            '/mlincr?_action=append&_action=train', method='post',
-            data=df_append.to_json(orient='records'),
-            headers={'Content-Type': 'application/json'})
-        self.assertEqual(resp.status_code, OK)
-        resp = self.get(
-            '/mlincr?_action=score', method='post',
-            data=self.df.to_json(orient='records'),
-            headers={'Content-Type': 'application/json'})
-        new_score = resp.json()['score']
-
-        # Score should improve by at least 30%
-        self.assertGreaterEqual(new_score - org_score, 0.3)  # NOQA: E912
 
     def test_filtercols(self):
         buff = StringIO()
@@ -406,4 +232,190 @@ class TestMLHandler(TestGramex):
             self.assertEqual(pipe.named_steps['LogisticRegression'].coef_.shape, (3, 1))
         finally:
             self.get('/mlhandler?_model&_opts&include&exclude', method='delete')
+            joblib.dump(clf, op.join(folder, 'model.pkl'))
+
+    def test_get_bulk_predictions(self):
+        df = self.df.drop_duplicates()
+        target = df.pop('species')
+        resp = self.get('/mlhandler', method='post', data=df.to_json(orient='records'),
+                        headers={'Content-Type': 'application/json'})
+        self.assertGreaterEqual(accuracy_score(target, resp.json()), self.ACC_TOL)
+
+    def test_get_bulk_score(self):
+        resp = self.get(
+            '/mlhandler?_action=score', method='post',
+            data=self.df.to_json(orient='records'),
+            headers={'Content-Type': 'application/json'})
+        self.assertGreaterEqual(resp.json()['score'], self.ACC_TOL)
+
+    def test_get_cache(self):
+        df = pd.DataFrame.from_records(self.get('/mlhandler?_cache=true').json())
+        pd.testing.assert_frame_equal(df, self.df)
+
+    def test_get_model_params(self):
+        params = self.get('/mlhandler?_model').json()
+        self.assertDictEqual(LogisticRegression().get_params(), params)
+
+    def test_get_predictions(self):
+        resp = self.get(
+            '/mlhandler?sepal_length=5.9&sepal_width=3&petal_length=5.1&petal_width=1.8')
+        self.assertEqual(resp.json(), ['virginica'])
+        req = '/mlhandler?'
+        samples = []
+        target = []
+        for row in self.df.sample(n=5).to_dict(orient='records'):
+            samples.extend([(col, value) for col, value in row.items() if col != 'species'])
+            target.append(row['species'])
+        params = '&'.join([f'{k}={v}' for k, v in samples])
+        resp = self.get(req + params)
+        self.assertGreaterEqual(accuracy_score(resp.json(), target), 0.8)  # NOQA: E912
+
+    def test_get_predictions_post_file(self):
+        df = self.df.drop_duplicates()
+        target = df.pop('species')
+        buff = StringIO()
+        df.to_csv(buff, index=False, encoding='utf8')
+        buff.seek(0)
+        resp = self.get('/mlhandler?_action=predict',
+                        method='post', files={'file': ('iris.csv', buff)})
+        self.assertGreaterEqual(accuracy_score(target, resp.json()), self.ACC_TOL)
+
+    def test_get_score(self):
+        req = '/mlhandler?_action=score&'
+        samples = []
+        for row in self.df.sample(n=5).to_dict(orient='records'):
+            samples.extend([(col, value) for col, value in row.items()])
+        params = '&'.join([f'{k}={v}' for k, v in samples])
+        resp = self.get(req + params)
+        self.assertGreaterEqual(resp.json()['score'], 0.6)  # NOQA: E912
+
+    def test_model_default_path(self):
+        clf = joblib.load(op.join(
+            gramex.config.variables['GRAMEXDATA'], 'apps', 'mlhandler', 'mlhandler-nopath.pkl'))
+        self.assertIsInstance(clf, Pipeline)
+        self.assertIsInstance(clf.named_steps['transform'], ColumnTransformer)
+        self.assertIsInstance(clf.named_steps['LogisticRegression'], LogisticRegression)
+        resp = self.get(
+            '/mlnopath?_action=score', method='post',
+            headers={'Content-Type': 'application/json'})
+        self.assertGreaterEqual(resp.json()['score'], self.ACC_TOL)
+
+    def test_post_after_delete_custom_model(self):
+        org_clf = joblib.load(op.join(folder, 'model.pkl'))
+        try:
+            r = self.get('/mlhandler?_model', method='delete')
+            self.assertEqual(r.status_code, OK)
+            self.assertFalse(op.exists(op.join(folder, 'model.pkl')))
+            # recreate the model
+            X, y = make_classification()  # NOQA: N806
+            xtrain, xtest, ytrain, ytest = train_test_split(X, y, stratify=y, test_size=0.25)
+            df = pd.DataFrame(xtrain)
+            df['target'] = ytrain
+            r = self.get('/mlhandler?_model&class=GaussianNB', method='put')
+            self.assertEqual(r.status_code, OK)
+            r = self.get('/mlhandler?_action=train&target_col=target', method='post',
+                         data=df.to_json(orient='records'),
+                         headers={'Content-Type': 'application/json'})
+            self.assertEqual(r.status_code, OK)
+            self.assertGreaterEqual(r.json()['score'], 0.8)  # NOQA: E912
+            clf = joblib.load(op.join(folder, 'model.pkl'))
+            self.assertIsInstance(clf.named_steps['GaussianNB'], GaussianNB)
+        finally:
+            joblib.dump(org_clf, op.join(folder, 'model.pkl'))
+
+    def test_post_after_delete_default_model(self):
+        clf = joblib.load(op.join(folder, 'model.pkl'))
+        try:
+            r = self.get('/mlhandler?_model', method='delete')
+            self.assertEqual(r.status_code, OK)
+            self.assertFalse(op.exists(op.join(folder, 'model.pkl')))
+            # recreate the model
+            X, y = make_classification()  # NOQA: N806
+            xtrain, xtest, ytrain, ytest = train_test_split(X, y, stratify=y, test_size=0.25)
+            df = pd.DataFrame(xtrain)
+            df['target'] = ytrain
+            r = self.get('/mlhandler?_action=train&target_col=target', method='post',
+                         data=df.to_json(orient='records'),
+                         headers={'Content-Type': 'application/json'})
+            self.assertEqual(r.status_code, OK)
+            self.assertGreaterEqual(r.json()['score'], 0.8)  # NOQA: E912
+        finally:
+            joblib.dump(clf, op.join(folder, 'model.pkl'))
+
+    def test_retrain(self):
+        # Make some data
+        x, y = make_classification()
+        xtrain, xtest, ytrain, ytest = train_test_split(x, y, stratify=y, test_size=0.25)
+        df = pd.DataFrame(xtrain)
+        df['target'] = ytrain
+        test_df = pd.DataFrame(xtest)
+        test_df['target'] = ytest
+        clf = joblib.load(op.join(folder, 'model.pkl'))
+        try:
+            # clear the cache
+            resp = self.get('/mlhandler?_cache', method='delete')
+            self.assertEqual(resp.status_code, OK)
+            resp = self.get('/mlhandler?_cache')
+            self.assertListEqual(resp.json(), [])
+            # append new data, don't train
+            self.get('/mlhandler?_action=append', method='post', data=df.to_json(orient='records'),
+                     headers={'Content-Type': 'application/json'})
+            # now, retrain
+            self.get('/mlhandler?_action=retrain&target_col=target', method='post')
+            # Check score against test dataset
+            resp = self.get(
+                '/mlhandler?_action=score', method='post',
+                data=test_df.to_json(orient='records'),
+                headers={'Content-Type': 'application/json'})
+            self.assertGreaterEqual(resp.json()['score'], 0.6)  # NOQA: E912
+        finally:
+            # revert to the original cache
+            self.get('/mlhandler?_cache', method='delete')
+            self.get('/mlhandler?_action=append', method='post',
+                     data=self.df.to_json(orient='records'),
+                     headers={'Content-Type': 'application/json'})
+            joblib.dump(clf, op.join(folder, 'model.pkl'))
+
+    def test_single_line_train_fetch_model(self):
+        clf = joblib.load(op.join(folder, 'model.pkl'))
+        try:
+            resp = self.get('/mlblank?_model&class=DecisionTreeClassifier&target_col=species',
+                            method='put')
+            self.assertEqual(resp.status_code, OK)
+            # train
+            line = StringIO()
+            self.df.head(1).to_csv(line, index=False, encoding='utf8')
+            line.seek(0)
+            resp = self.get('/mlblank?_action=train', method='post',
+                            files={'file': ('iris.csv', line.read())})
+            self.assertEqual(resp.status_code, OK)
+            self.assertGreaterEqual(resp.json()['score'], 0.0)
+
+            # get the model
+            resp = self.get('/mlblank')
+            self.assertEqual(resp.status_code, OK)
+        finally:
+            joblib.dump(clf, op.join(folder, 'model.pkl'))
+
+    def test_template(self):
+        """Check if viewing the template works fine."""
+        r = self.get('/mlhandler')
+        self.assertEqual(r.status_code, OK)
+        # Try getting predictions
+        self.test_get_predictions()
+        self.test_get_bulk_predictions()
+
+    def test_train(self):
+        # backup the original model
+        clf = joblib.load(op.join(folder, 'model.pkl'))
+        X, y = make_classification()  # NOQA: N806
+        xtrain, xtest, ytrain, ytest = train_test_split(X, y, stratify=y, test_size=0.25)
+        df = pd.DataFrame(xtrain)
+        df['target'] = ytrain
+        try:
+            resp = self.get('/mlhandler?_action=train&target_col=target', method='post',
+                            data=df.to_json(orient='records'),
+                            headers={'Content-Type': 'application/json'})
+            self.assertGreaterEqual(resp.json()['score'], 0.8)  # NOQA: E912
+        finally:
             joblib.dump(clf, op.join(folder, 'model.pkl'))


### PR DESCRIPTION
Rendering any template in MLHandler accidentally drops the target
column. Fixing this. Closes #361 