### PR TITLE
REQ: Restrict nodejs to LTS versions

### DIFF
--- a/pkg/conda/template.meta.yaml
+++ b/pkg/conda/template.meta.yaml
@@ -41,7 +41,7 @@ requirements:
   run:
     - python          # REQ: conda: Base Python
     - pip             # REQ: conda: Set up pip packages
-    - nodejs>=7.6     # REQ: conda: CaptureHandler, apps/ui, etc
+    - nodejs>=7.6,<=14 # REQ: conda: CaptureHandler, apps/ui, etc
     - yarn            # REQ: conda: gramex setup (conda-forge)
     - conda
     {% for entry in release.conda %}


### PR DESCRIPTION
The latest nodejs version available under conda-forge is not stable,
which causes this error:
https://stackoverflow.com/questions/64612707/node-sass-does-not-yet-support-your-current-environment-windows-64-bit-with-uns