### PR TITLE
Initialize tables on first load in forms 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+# ignore todo files
 TODO
+*.todo
 
 # Ignore auto-generated documentation
 docs/gramex*.rst

--- a/gramex/apps/forms/form.html
+++ b/gramex/apps/forms/form.html
@@ -21,7 +21,7 @@
   <body>
     {% include 'template-navbar-view-form.html' %}
     <div class="container my-3">
-      <ul class="nav nav-tabs" id="myTab" role="tablist">
+      <ul class="nav nav-tabs" id="formTab" role="tablist">
         <li class="nav-item" role="presentation">
           <a class="nav-link active" id="questions-tab" data-toggle="tab" href="#questions" role="tab" aria-controls="questions" aria-selected="true">Questions</a>
         </li>
@@ -29,18 +29,20 @@
           <a class="nav-link" id="responses-tab" data-toggle="tab" href="#responses" role="tab" aria-controls="responses" aria-selected="false">Responses</a>
         </li>
       </ul>
-      <div class="tab-content" id="myTabContent">
+      <div class="tab-content" id="formTabContent">
         <div class="tab-pane fade show active" id="questions" role="tabpanel" aria-labelledby="questions-tab">
           <div class="my-5" id="view-form">
             <form></form>
+            <small class="text-muted">You are currently previewing the form.</small>
           </div>
         </div>
         <div class="tab-pane fade w-100" id="responses" role="tabpanel" aria-labelledby="responses-tab">
-          <div class="formhandler pt-3 mt-3" data-src="../analytics/?db={{ form_id }}" data-export="false" data-count="true" data-page-size="5"></div>
+          <div class="formhandler pt-3 mt-3" data-export="false" data-count="true" data-page-size="5"></div>
         </div>
       </div>
       <p>
         <a class="btn btn-success" href="{{ base }}/create?id={{ form_id }}">Edit</a>
+        <a class="btn btn-primary" href="{{ base }}/view/{{ form_id }}">View form</a>
       </p>
     </div>
 
@@ -61,9 +63,14 @@
     <script>
       /* exported hljs, dragula, form_id */
       const form_id = '{% raw form_id %}'
-      $('.formhandler').formhandler({
-        columns: [{name: "*" }, { name: "response", hide: true}]
-      })
+      fetch(`../analytics/?db=${form_id}`)
+        .then(response => response.json())
+        .then(function(response) {
+          $('.formhandler').formhandler({
+            data: response['each_form'],
+            columns: [{name: "*" }, { name: "response", hide: true}]
+          })
+        })
     </script>
     <script src="{{ base }}/js/view-form.js"></script>
   </body>

--- a/gramex/apps/forms/form_builder.py
+++ b/gramex/apps/forms/form_builder.py
@@ -12,7 +12,6 @@ from gramex.services import info
 from gramex.transforms import handler
 from tornado.web import HTTPError
 import pandas as pd
-from sqlalchemy.exc import NoSuchTableError
 
 FOLDER = os.path.abspath(os.path.dirname(__file__))
 TARGET = os.path.join(var.GRAMEXDATA, 'forms', 'thumbnail')

--- a/gramex/apps/forms/form_builder.py
+++ b/gramex/apps/forms/form_builder.py
@@ -1,6 +1,4 @@
 import os
-import re
-import sqlite3
 import gramex.data
 from io import BytesIO
 from ast import literal_eval

--- a/gramex/apps/forms/form_builder.py
+++ b/gramex/apps/forms/form_builder.py
@@ -23,7 +23,7 @@ if not os.path.exists(TARGET):
 
 
 def modify_columns(handler, data):
-    if handler.request.method == 'GET':
+    if handler.request.method == 'GET' and len(data):
         # process json response
         s = data['response'].apply(literal_eval)
 
@@ -96,24 +96,3 @@ def screenshots(kwargs, host):
     except Exception:
         app_log.exception('Screenshot failed')
         raise
-
-
-def create_form_tables():
-    """Create database and tables if they don't exist.
-    Runs on forms import (scheduler) or on demand at /configure."""
-    db_path = var['FORMS_URL']
-    db_path = re.sub(r'^sqlite:///', '', db_path)
-    if(not os.path.isfile(db_path)):
-        try:
-            response = gramex.data.filter(url=var.FORMS_URL, table=var.FORMS_TABLE)
-            return "table exists"
-        except NoSuchTableError:
-            conn = sqlite3.connect(db_path)
-            conn.execute(
-                'CREATE TABLE "forms" (`id`	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,\
-                `metadata` TEXT, `config` TEXT, `thumbnail` TEXT, `html` TEXT, `user` TEXT)')
-            conn.execute('CREATE TABLE `analytics`(`id` INTEGER, `response` TEXT)')
-            conn.close()
-            return "created necessary tables"
-    else:
-        return "tables exist already"

--- a/gramex/apps/forms/gramex.yaml
+++ b/gramex/apps/forms/gramex.yaml
@@ -17,6 +17,11 @@ import:
     path: $GRAMEXAPPS/admin2/gramex.yaml
     YAMLURL: $YAMLURL/admin/
 
+schedule:
+  setup_form_tables:
+    function: form_builder.create_form_tables()
+    startup: true
+
 # Configurations for app: form_builder
 # ----------------------------------------------------------------------------
 url:
@@ -94,11 +99,6 @@ url:
       function: form_builder.endpoint(handler)
       headers:
         Access-Control-Allow-Origin: '*'        # Allow CORS from any domain
-  forms/dbcheck-$*:
-    pattern: /$YAMLURL/dbcheck
-    handler: FunctionHandler
-    kwargs:
-      function: form_builder.db_check
   forms/analytics-$*:
     pattern: /$YAMLURL/analytics/(.*)
     handler: FormHandler
@@ -126,3 +126,8 @@ url:
         Content-Type: text/plain
         Content-Disposition: none
         Cache-Control: "public, max-age=86400"
+  forms-create-tables:
+    pattern: /$YAMLURL/configure
+    handler: FunctionHandler
+    kwargs:
+      function: form_builder.create_form_tables

--- a/gramex/apps/forms/gramex.yaml
+++ b/gramex/apps/forms/gramex.yaml
@@ -72,6 +72,16 @@ url:
       table: $FORMS_TABLE
       id: $FORMS_ID
       modify: form_builder.after_publish(handler, data)
+      columns:
+        metadata: TEXT
+        config: TEXT
+        thumbnail: TEXT
+        html: TEXT
+        user: TEXT
+        id:
+          type: INTEGER
+          primary_key: true
+          autoincrement: true
   forms/thumbnail-$*:
     pattern: /$YAMLURL/thumbnail/(.*)
     handler: FileHandler
@@ -103,18 +113,28 @@ url:
     pattern: /$YAMLURL/analytics/(.*)
     handler: FormHandler
     kwargs:
-      url: 'sqlite:///$GRAMEXDATA/forms/form_{db}.db'    # Pick any database
-      table: analytics                                   # Pick any table name to create
-      id: id                      # The "id" column is primary key
-      # Define your table's columns
-      columns:
-        response: TEXT            # Use any SQL type allowed by DB
-        id:
-          type: INTEGER           # Define an integer ID column
-          primary_key: true       # as a primary key
-          autoincrement: true     # that auto-increments
-        form_id: INTEGER
-      modify: form_builder.modify_columns(handler, data)
+      each_form:
+        url: 'sqlite:///$GRAMEXDATA/forms/form_{db}.db'    # Pick any database
+        table: analytics                                   # Pick any table name to create
+        id: id                      # The "id" column is primary key
+        columns:
+          response: TEXT            # Use any SQL type allowed by DB
+          id:
+            type: INTEGER           # Define an integer ID column
+            primary_key: true       # as a primary key
+            autoincrement: true     # that auto-increments
+          form_id: INTEGER
+        modify: form_builder.modify_columns(handler, data)
+      analytics:
+        url: 'sqlite:///$GRAMEXDATA/forms/forms.db'    # Pick any database
+        table: analytics                                   # Pick any table name to create
+        id: id                      # The "id" column is primary key
+        columns:
+          response: TEXT            # Use any SQL type allowed by DB
+          id:
+            type: INTEGER           # Define an integer ID column
+            primary_key: true       # as a primary key
+            autoincrement: true     # that auto-increments
 
   forms/snippets/all:
     pattern: /$YAMLURL/snippets/
@@ -126,8 +146,3 @@ url:
         Content-Type: text/plain
         Content-Disposition: none
         Cache-Control: "public, max-age=86400"
-  forms-create-tables:
-    pattern: /$YAMLURL/configure
-    handler: FunctionHandler
-    kwargs:
-      function: form_builder.create_form_tables

--- a/gramex/apps/forms/gramex.yaml
+++ b/gramex/apps/forms/gramex.yaml
@@ -17,11 +17,6 @@ import:
     path: $GRAMEXAPPS/admin2/gramex.yaml
     YAMLURL: $YAMLURL/admin/
 
-schedule:
-  setup_form_tables:
-    function: form_builder.create_form_tables()
-    startup: true
-
 # Configurations for app: form_builder
 # ----------------------------------------------------------------------------
 url:

--- a/gramex/apps/forms/style.scss
+++ b/gramex/apps/forms/style.scss
@@ -79,3 +79,7 @@
   position: sticky;
   top: 5%;
 }
+// disable events while previewing the form at /form/id
+#formTabContent form {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Problem
forms.db and analytics, forms tables need to be created before forms app can be used.

## Solution
- introduce [formhandler](https://learn.gramener.com/guide/formhandler/#formhandler-columns) columns-based table creation for `analytics` and `forms` tables
  - downstream impact: update data-source for `.formhandler()` in form.html
- disable mouse events while previewing the form at `/form/id`
  -  add a prominent way to View form in addition to a link in navbar 

Without this, forms app wouldn't work.