### PR TITLE
BLD: Use local source for conda; fix miniconda version for Docker

### DIFF
--- a/pkg/conda/template.meta.yaml
+++ b/pkg/conda/template.meta.yaml
@@ -3,8 +3,9 @@ package:
   version: "{{ release.info.version }}"
 
 source:
-  git_url: {{ release.info.download_url }}.git
-  git_rev: v{{ release.info.version }}
+  # Gramex >=1.67 requires git lfs on the build machine. Specifying git sources here breaks it.
+  # Use local path for the source instead.
+  path: ../../
 
 about:
   home: "{{ release.info.url }}"

--- a/pkg/docker-py3/Dockerfile.tmpl
+++ b/pkg/docker-py3/Dockerfile.tmpl
@@ -1,4 +1,5 @@
-FROM continuumio/miniconda3:latest
+# Pin miniconda3 version to the latest one that has Python 3.7 in the base env
+FROM continuumio/miniconda3:4.8.2
 
 LABEL description="{{ description }}"
 LABEL version="{{ version }}"


### PR DESCRIPTION
1. Gramex >=1.67 requires git lfs on the build machine. Specifying git sources in the conda recipe breaks it. Use local path for the source instead.
2. In the Dockerfile, pin miniconda3 version to the latest one that has Python 3.7 in the base env.