### PR TITLE
BUG: Fix origin check in WebSocketHandler

### DIFF
--- a/gramex/handlers/websockethandler.py
+++ b/gramex/handlers/websockethandler.py
@@ -48,6 +48,6 @@ class WebSocketHandler(BaseWebSocketHandler):
             origins = [origins]
         domain = urlparse(origin).netloc
         for allowed_origin in origins:
-            if domain.netloc.endswith(allowed_origin):
+            if domain.endswith(allowed_origin):
                 return True
         return False


### PR DESCRIPTION
We're accidentally checking for `domain.netloc`, where domain is a string.