### PR TITLE
FIX: Enforce correct order of features before prediction in MLHandler

### DIFF
--- a/gramex/handlers/mlhandler.py
+++ b/gramex/handlers/mlhandler.py
@@ -339,6 +339,8 @@ class MLHandler(FormHandler):
             target = data[score_col]
             data = data.drop([score_col], axis=1)
             return self.model.score(data, target)
+        # Set data in the same order as the transformer requests
+        data = data[self.model.named_steps['transform']._feature_names_in]
         data[self.get_opt('target_col', _prediction_col)] = self.model.predict(data)
         return data
 

--- a/tests/test_mlhandler.py
+++ b/tests/test_mlhandler.py
@@ -265,6 +265,8 @@ class TestMLHandler(TestGramex):
              'petal_length': 5.1, 'petal_width': 1.8,
              target_col: 'virginica'}
         ])
+        resp = self.get(
+            '/mlhandler?sepal_width=3&petal_length=5.1&sepal_length=5.9&petal_width=1.8')
         req = '/mlhandler?'
         samples = []
         target = []


### PR DESCRIPTION
Required for fixing #377
Since v0.24, sklearn's column transformers need the same order of
feature names between .fit and .predict. We can still send URL
parameters in any order, but they need to be ordered correctly by the
MLHandler. See sklearn's release notes for more:
https://scikit-learn.org/stable/whats_new/v0.24.html#sklearn-compose