### PR TITLE
PKG: Conda - Don't compile untracked .py files from local sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ test: test-setup
 	$(PYTHON) setup.py nosetests
 
 conda:
+	git clean -fdx
 	# conda install conda-build
 	python pkg/conda/conda-setup.py
 	conda build -c conda-forge pkg/conda/

--- a/pkg/conda/template.post-link.bat
+++ b/pkg/conda/template.post-link.bat
@@ -1,7 +1,7 @@
 SETLOCAL ENABLEDELAYEDEXPANSION
 
 {% for entry in release.pip %}
-"!PREFIX!\Scripts\pip.exe" install --use-feature=2020-resolver {% raw entry %}
+"!PREFIX!\Scripts\pip.exe" install {% raw entry %}
 {% end %}
 call "!PREFIX!\Library\bin\yarn.cmd" config set ignore-engines true
 "!PREFIX!\Scripts\gramex.exe" setup --all

--- a/pkg/conda/template.post-link.sh
+++ b/pkg/conda/template.post-link.sh
@@ -1,5 +1,5 @@
 {% for entry in release.pip %}
-"$PREFIX/bin/pip" install --use-feature=2020-resolver {% raw entry %}
+"$PREFIX/bin/pip" install {% raw entry %}
 {% end %}
 
 "$PREFIX/bin/yarn" config set ignore-engines true


### PR DESCRIPTION
Since we started building conda packages from local sources instead of
PyPI (see 13ca54f), all .py files under
the source path get compiled, even the ones in apps/*/node_modules,
which inflates the conda package. This commit enforces a make clean
before make conda.