### PR TITLE
GRAMEX-89 ⁃ Admin page enhancements

### DIFF
--- a/gramex/apps/admin2/gramex.yaml
+++ b/gramex/apps/admin2/gramex.yaml
@@ -66,8 +66,9 @@ url:
 
   apps/admin2/auth-rules-$*:
     pattern: /$YAMLURL/auth-rules
-    handler: gramexadmin.AuthRulesFormHandler
+    handler: gramexadmin.AdminFormHandler
     kwargs:
+      rules: true
       admin_kwargs: $ADMIN_KWARGS
       auth: $ADMIN_AUTH
 

--- a/gramex/apps/admin2/gramex.yaml
+++ b/gramex/apps/admin2/gramex.yaml
@@ -63,6 +63,11 @@ url:
     kwargs:
       admin_kwargs: $ADMIN_KWARGS
       auth: $ADMIN_AUTH
+      signup:
+        email_subject: Welcome to your Gramex app!
+        email_text: |
+          Hello {user},
+          You have been signed up with password {password}.
 
   apps/admin2/auth-rules-$*:
     pattern: /$YAMLURL/auth-rules

--- a/gramex/apps/admin2/gramex.yaml
+++ b/gramex/apps/admin2/gramex.yaml
@@ -64,6 +64,13 @@ url:
       admin_kwargs: $ADMIN_KWARGS
       auth: $ADMIN_AUTH
 
+  apps/admin2/auth-rules-$*:
+    pattern: /$YAMLURL/auth-rules
+    handler: gramexadmin.AuthRulesFormHandler
+    kwargs:
+      admin_kwargs: $ADMIN_KWARGS
+      auth: $ADMIN_AUTH
+
   app/admin2/schedule-$*:
     pattern: /$YAMLURL/schedule-data
     handler: FunctionHandler

--- a/gramex/apps/admin2/gramexadmin.py
+++ b/gramex/apps/admin2/gramexadmin.py
@@ -102,18 +102,16 @@ class AdminFormHandler(gramex.handlers.FormHandler):
             df = gramex.data.filter(
                 **{k: v for k, v in self.auth_conf.kwargs.items() if k in filter_kwargs}
             )
-            df = df[df[col].str.contains(pattern)]
-
             change = self.get_arg('change')
             to = self.get_arg('to')
-            df[change] = to
-            df.index.name = "id"
+            df.loc[df.index[df[col].str.contains(pattern)], change] = to
+
             yield gramex.service.threadpool.submit(
                 gramex.data.update,
                 url=self.auth_conf.kwargs.url,
                 args=df.to_dict(orient='list'),
-                id=['id'],
-                table=self.auth_conf.kwargs['table']
+                id=[self.auth_conf.kwargs.user.column],
+                table=self.auth_conf.kwargs.get('table')
             )
         else:
             super(AdminFormHandler, self).put(*path_args, **path_kwargs)

--- a/gramex/apps/admin2/gramexadmin.py
+++ b/gramex/apps/admin2/gramexadmin.py
@@ -97,6 +97,22 @@ class AdminFormHandler(gramex.handlers.FormHandler):
         raise HTTPError(INTERNAL_SERVER_ERROR, reason=self.reason)
 
 
+class AuthRulesFormHandler(gramex.handlers.FormHandler):
+    @classmethod
+    def setup(cls, **kwargs):
+        try:
+            cls.authhandler, cls.auth_conf, data_conf = get_auth_conf(
+                kwargs.get('admin_kwargs', {}))
+        except ValueError as e:
+            super(gramex.handlers.FormHandler, cls).setup(**kwargs)
+            app_log.warning('%s: %s', cls.name, e.args[0])
+            cls.reason = e.args[0]
+            cls.get = cls.post = cls.put = cls.delete = cls.send_response
+            return
+        if 'rules' in cls.auth_conf.kwargs:
+            super(AuthRulesFormHandler, cls).setup(**cls.auth_conf.kwargs['rules'])
+
+
 def evaluate(handler, code):
     """Evaluates Python code in a WebSocketHandler, like a REPL"""
     retval = None

--- a/gramex/apps/admin2/gramexadmin.py
+++ b/gramex/apps/admin2/gramexadmin.py
@@ -70,7 +70,7 @@ class AdminFormHandler(gramex.handlers.FormHandler):
         email_col = email.get('email_column', 'email')
         to = self.get_arg(email_col, False)
         if not to:
-            app_log.warning('No email address found for new user {handler.get_arg("user")}.')
+            app_log.warning('No email address found for new user {self.get_arg("user")}.')
             return
 
         mailer = gramex.service.email.get(email.email_from, False)

--- a/gramex/apps/admin2/gramexadmin.py
+++ b/gramex/apps/admin2/gramexadmin.py
@@ -45,32 +45,11 @@ def get_auth_conf(kwargs):
         user_column = auth_kwargs.get('user', {}).get('column', 'user')
         data_conf = gramex.handlers.DBAuth.clear_special_keys(
             auth_kwargs.copy(), 'rules', 'user', 'password', 'forgot',
-            'signup', 'template', 'delay')
+            'signup', 'template', 'delay', 'email_column')
         data_conf['id'] = user_column
         return authhandler, auth_conf, data_conf
     else:
         raise ValueError('Missing lookup: in url.%s (authhandler)' % authhandler)
-
-
-@coroutine
-def send_welcome_email(handler):
-    if handler.request.method == 'POST':
-        to = handler.get_arg('email', False)
-        if not to:
-            app_log.warning('No email address found for new user {handler.get_arg("user")}.')
-            return
-        email = handler.auth_conf.kwargs.get('forgot', False)
-        if not email:
-            app_log.warning('No email sender found in config.')
-            return
-        mailer = gramex.service.email[email.email_from]
-        yield gramex.service.threadpool.submit(
-            mailer.mail,
-            to=to, subject='Welcome to your Gramex app!',
-            body=dedent(f'''
-                Hello {handler.get_arg('user')},
-                You have been signed up with password {handler.get_arg('user')}.''')
-        )
 
 
 class AdminFormHandler(gramex.handlers.FormHandler):
@@ -79,17 +58,52 @@ class AdminFormHandler(gramex.handlers.FormHandler):
     It lookup up "auth-handler" in the gramex config. If it has a "lookup:" or is a "DBAuth",
     creates a FormHandler using that url: and other parameters.
     '''
+
+    @coroutine
+    def send_welcome_email(self):
+        if self.request.method != 'POST':
+            return
+        email = self.auth_conf.kwargs.get('forgot', False)
+        if not email:
+            app_log.warning(f'No email config found in {self.name}.')
+            return
+        email_col = email.get('email_column', 'email')
+        to = self.get_arg(email_col, False)
+        if not to:
+            app_log.warning('No email address found for new user {handler.get_arg("user")}.')
+            return
+
+        mailer = gramex.service.email.get(email.email_from, False)
+        if not mailer:
+            app_log.warning(f'No email service named {email.email_from}.')
+            return
+        user = {k: v[0] for k, v in self.args.items()}
+        subject = email.get('email_subject', 'Welcome to your Gramex app!')
+        body = email.get(
+            'email_text',
+            dedent('Hello {user},\nYou have been signed up with password {password}.')
+        )
+        yield gramex.service.threadpool.submit(
+            mailer.mail,
+            to=to, subject=subject.format(**user),
+            body=body.format(**user)
+        )
+
     @classmethod
     def setup(cls, **kwargs):
         # admin_kwargs.authhandler is a url: key that holds an AuthHandler. Get its kwargs
         try:
             admin_kwargs = kwargs.get('admin_kwargs', {})
+            if not admin_kwargs:
+                raise ValueError(f'admin_kwargs not found in {cls.name}.')
             if kwargs.get('rules', False):
                 # Get the rules for formhandler
                 authhandler = admin_kwargs.get('authhandler', False)
                 if not authhandler:
-                    raise ValueError('Missing authhandler.')
-                data_conf = gramex.conf['url'].get(authhandler, {}).kwargs.get('rules', {}).copy()
+                    raise ValueError(f'Missing authhandler in url {cls.name}.')
+                data_conf = gramex.conf['url'].get(
+                    authhandler, {}
+                ).get('kwargs', {}).get('rules', {}).copy()
                 data_conf['id'] = ['selector', 'pattern']
             else:
                 cls.authhandler, cls.auth_conf, data_conf = get_auth_conf(
@@ -103,7 +117,7 @@ class AdminFormHandler(gramex.handlers.FormHandler):
         # Get the FormHandler configuration from lookup:
         cls.conf.kwargs = data_conf
         super(AdminFormHandler, cls).setup(**cls.conf.kwargs)
-        cls._on_finish_methods.append(send_welcome_email)
+        cls._on_finish_methods.append(cls.send_welcome_email)
 
     def send_response(self, *args, **kwargs):
         raise HTTPError(INTERNAL_SERVER_ERROR, reason=self.reason)

--- a/gramex/apps/admin2/gramexadmin.py
+++ b/gramex/apps/admin2/gramexadmin.py
@@ -80,7 +80,8 @@ class AdminFormHandler(gramex.handlers.FormHandler):
     def setup(cls, **kwargs):
         # admin_kwargs.authhandler is a url: key that holds an AuthHandler. Get its kwargs
         try:
-            authhandler, auth_conf, data_conf = get_auth_conf(kwargs.get('admin_kwargs', {}))
+            cls.authhandler, cls.auth_conf, data_conf = get_auth_conf(
+                kwargs.get('admin_kwargs', {}))
         except ValueError as e:
             super(gramex.handlers.FormHandler, cls).setup(**kwargs)
             app_log.warning('%s: %s', cls.name, e.args[0])

--- a/gramex/apps/admin2/index.html
+++ b/gramex/apps/admin2/index.html
@@ -91,7 +91,6 @@
         </td>
       </script>
       {% if authhandler %}
-      {% set print(auth_conf) %}
         <div class="row">
           <div class="col">
             <div class="users" data-src="users-data">

--- a/gramex/apps/admin2/index.html
+++ b/gramex/apps/admin2/index.html
@@ -98,7 +98,39 @@
             </div>
           </div>
           <div class="col">
-            <div id="usermanage"></div>
+            <div id="usermanage">
+              <h3>Modify User Attributes</h3>
+              <br>
+              <form id="moduser" enctype="multipart/form-data">
+                <template id="moduser-tmpl">
+                  <div class="form-group row">
+                    <label for="attrfilter" class="col-sm-2 col-form-label">Filter:</label>
+                    <select id="attrfilter" name="user-attr" class="form-control col-sm-4">
+                      <% usercols.forEach(function(a) { %>
+                      <option value="<%= a %>"><%= a %></option>
+                      <% }) %>
+                    </select>
+                  </div>
+                  <div class="form-group row">
+                    <label for="attrpattern" class="col-sm-2 col-form-label">By:</label>
+                    <input type="text" id="attrparttern" name="pattern" class="form-control col-sm-4">
+                  </div>
+                  <div class="form-group row">
+                    <label for="attrchange" class="col-sm-2 col-form-label">Change:</label>
+                    <select id="attrchange" name="change" class="form-control col-sm-4">
+                      <% usercols.forEach(function(a) { %>
+                      <option value="<%= a %>"><%= a %></option>
+                      <% }) %>
+                    </select>
+                  </div>
+                  <div class="form-group row">
+                    <label for="attrto" class="col-sm-2 col-form-label">To:</label>
+                    <input type="text" id="attrto" name="to" class="form-control col-sm-4">
+                  </div>
+                </template>
+                <button type="submit" class="btn btn-primary mb-2">Ok</button>
+              </form>
+            </div>
           </div>
         </div>
       {% else %}
@@ -120,27 +152,44 @@
         var user_key = (kwargs.user || {}).arg || 'user'
         var user_column = (kwargs.user || {}).column || 'user'
         var password_column = (kwargs.password || {}).column || 'password'
-        $('.users').formhandler({
-          edit: true,
-          add: true,
-          columns: [
-            { name: '*' },
-            {
-              name: password_column,
-              format: function(obj) { return '*'.repeat(obj.value.length) },
-              editable: {input: 'password'}
-            },
-            { name: 'actions', template: $('#action-template').html() }
-          ],
-          actions: [{
-            'reset': function(obj) {
-              var data = {}
-              data[user_key] = obj.row[user_column]
-              return $.ajax(auth_conf.pattern + '?' + forgot_key, {method: 'POST', data: data})
-                .done(function() { obj.notify('Email sent') })
-            }
-          }]
+        const render_fh = function() {
+          $('.users')
+            .on('load', function(obj) {
+              $('#moduser-tmpl').template({usercols: _.map(obj.meta.columns, 'name')})
+            })
+            .formhandler({
+            edit: true,
+            add: true,
+            columns: [
+              { name: '*' },
+              {
+                name: password_column,
+                format: function(obj) { return '*'.repeat(obj.value.length) },
+                editable: {input: 'password'}
+              },
+              { name: 'actions', template: $('#action-template').html() }
+            ],
+            actions: [{
+              'reset': function(obj) {
+                var data = {}
+                data[user_key] = obj.row[user_column]
+                return $.ajax(auth_conf.pattern + '?' + forgot_key, {method: 'POST', data: data})
+                  .done(function() { obj.notify('Email sent') })
+              }
+            }]
+          })
+        }
+        $('#moduser').submit(function(e) {
+          e.preventDefault()
+          $.ajax({
+            method: 'PUT',
+            url: 'users-data?fromadmin=true&' + $(this).serialize(),
+            success: render_fh
+          })
         })
+        render_fh()
+
+
       </script>
 
     {% elif current_tab == 'schedule' %}

--- a/gramex/apps/admin2/index.html
+++ b/gramex/apps/admin2/index.html
@@ -113,7 +113,7 @@
                   </div>
                   <div class="form-group row">
                     <label for="attrpattern" class="col-sm-2 col-form-label">By:</label>
-                    <input type="text" id="attrparttern" name="pattern" class="form-control col-sm-4">
+                    <input type="text" id="attrpattern" name="pattern" class="form-control col-sm-4">
                   </div>
                   <div class="form-group row">
                     <label for="attrchange" class="col-sm-2 col-form-label">Change:</label>
@@ -152,10 +152,28 @@
         var user_key = (kwargs.user || {}).arg || 'user'
         var user_column = (kwargs.user || {}).column || 'user'
         var password_column = (kwargs.password || {}).column || 'password'
+        var currdata = []
         const render_fh = function() {
           $('.users')
             .on('load', function(obj) {
-              $('#moduser-tmpl').template({usercols: _.map(obj.meta.columns, 'name')})
+              currdata = obj.formdata
+              let filters = _.pickBy(
+                g1.url.parse(g1.url.parse(window.location.href).hash).searchKey,
+                (val, key) => key.endsWith('~')
+              )
+              $('#moduser-tmpl').template({
+                usercols: _.map(obj.meta.columns, 'name'),
+              })
+              if (Object.keys(filters).length) {
+                let col = Object.keys(filters)[0]
+                $('#attrfilter').val(col.replace(/~$/, ''))
+                $('#attrpattern').val(filters[col])
+              }
+              $('#attrpattern').change(function() {
+                url = g1.url.parse(window.location.href)
+                url.hash = '?' + $('#attrfilter').val() + '~=' + $(this).val()
+                window.location = url.toString()
+              })
             })
             .formhandler({
             edit: true,
@@ -181,10 +199,18 @@
         }
         $('#moduser').submit(function(e) {
           e.preventDefault()
-          $.ajax({
-            method: 'PUT',
-            url: 'users-data?fromadmin=true&' + $(this).serialize(),
-            success: render_fh
+          let to_change = $('#attrchange').val()
+          let newval = $('#attrto').val()
+          opts = {method: 'PUT', url: 'users-data'}
+          currdata.forEach(function(elem, ix) {
+            elem[to_change] = newval
+            opts.data = elem
+            if (ix == currdata.length - 1) {
+              opts['success'] = render_fh
+            } else {
+              opts['success'] = console.log
+            }
+            $.ajax(opts)
           })
         })
         render_fh()

--- a/gramex/apps/admin2/index.html
+++ b/gramex/apps/admin2/index.html
@@ -91,8 +91,16 @@
         </td>
       </script>
       {% if authhandler %}
-        <div class="users" data-src="users-data">
-          <i class="fa fa-spinner fa-spin fa-3x text-center d-block"></i>
+      {% set print(auth_conf) %}
+        <div class="row">
+          <div class="col">
+            <div class="users" data-src="users-data">
+              <i class="fa fa-spinner fa-spin fa-3x text-center d-block"></i>
+            </div>
+          </div>
+          <div class="col">
+            <div id="usermanage"></div>
+          </div>
         </div>
       {% else %}
         <div class="alert alert-danger">
@@ -118,7 +126,11 @@
           add: true,
           columns: [
             { name: '*' },
-            { name: password_column, hide: true },
+            {
+              name: password_column,
+              format: function(obj) { return '*'.repeat(obj.value.length) },
+              editable: {input: 'password'}
+            },
             { name: 'actions', template: $('#action-template').html() }
           ],
           actions: [{

--- a/gramex/apps/admin2/index.html
+++ b/gramex/apps/admin2/index.html
@@ -97,41 +97,16 @@
               <i class="fa fa-spinner fa-spin fa-3x text-center d-block"></i>
             </div>
           </div>
+          {% if auth_conf.kwargs.get('rules', False) %}
           <div class="col">
-            <div id="usermanage">
-              <h3>Modify User Attributes</h3>
-              <br>
-              <form id="moduser" enctype="multipart/form-data">
-                <template id="moduser-tmpl">
-                  <div class="form-group row">
-                    <label for="attrfilter" class="col-sm-2 col-form-label">Filter:</label>
-                    <select id="attrfilter" name="user-attr" class="form-control col-sm-4">
-                      <% usercols.forEach(function(a) { %>
-                      <option value="<%= a %>"><%= a %></option>
-                      <% }) %>
-                    </select>
-                  </div>
-                  <div class="form-group row">
-                    <label for="attrpattern" class="col-sm-2 col-form-label">By:</label>
-                    <input type="text" id="attrpattern" name="pattern" class="form-control col-sm-4">
-                  </div>
-                  <div class="form-group row">
-                    <label for="attrchange" class="col-sm-2 col-form-label">Change:</label>
-                    <select id="attrchange" name="change" class="form-control col-sm-4">
-                      <% usercols.forEach(function(a) { %>
-                      <option value="<%= a %>"><%= a %></option>
-                      <% }) %>
-                    </select>
-                  </div>
-                  <div class="form-group row">
-                    <label for="attrto" class="col-sm-2 col-form-label">To:</label>
-                    <input type="text" id="attrto" name="to" class="form-control col-sm-4">
-                  </div>
-                </template>
-                <button id='modbtn' type="submit" class="btn btn-primary mb-2" disabled>Ok</button>
-              </form>
+            <div class="row"><h3>Modify User Attributes</h3></div>
+            <div class="row">
+              <div class="auth-rules" data-src="auth-rules">
+                <i class="fa fa-spinner fa-spin fa-3x text-center d-block"></i>
+              </div>
             </div>
           </div>
+          {% end %}
         </div>
       {% else %}
         <div class="alert alert-danger">
@@ -152,75 +127,28 @@
         var user_key = (kwargs.user || {}).arg || 'user'
         var user_column = (kwargs.user || {}).column || 'user'
         var password_column = (kwargs.password || {}).column || 'password'
-        var currdata = []
-        const render_fh = function() {
-          $('.users')
-            .on('load', function(obj) {
-              currdata = obj.formdata
-              let filters = _.pickBy(
-                g1.url.parse(g1.url.parse(window.location.href).hash).searchKey,
-                (val, key) => key.endsWith('~')
-              )
-              $('#moduser-tmpl').template({
-                usercols: _.map(obj.meta.columns, 'name'),
-              })
-              if (Object.keys(filters).length) {
-                let col = Object.keys(filters)[0]
-                $('#attrfilter').val(col.replace(/~$/, ''))
-                $('#attrpattern').val(filters[col])
-              }
-              $('#attrpattern').change(function() {
-                if ($(this).val()) {
-                  $('#modbtn').prop('disabled', false)
-                } else {
-                  $('#modbtn').prop('disabled', true)
-                }
-                url = g1.url.parse(window.location.href)
-                url.hash = '?' + $('#attrfilter').val() + '~=' + $(this).val()
-                window.location = url.toString()
-              })
-            })
-            .formhandler({
-            edit: true,
-            add: true,
-            columns: [
-              { name: '*' },
-              {
-                name: password_column,
-                format: function(obj) { return '*'.repeat(obj.value.length) },
-                editable: {input: 'password'}
-              },
-              { name: 'actions', template: $('#action-template').html() }
-            ],
-            actions: [{
-              'reset': function(obj) {
-                var data = {}
-                data[user_key] = obj.row[user_column]
-                return $.ajax(auth_conf.pattern + '?' + forgot_key, {method: 'POST', data: data})
-                  .done(function() { obj.notify('Email sent') })
-              }
-            }]
-          })
-        }
-        $('#moduser').submit(function(e) {
-          e.preventDefault()
-          let to_change = $('#attrchange').val()
-          let newval = $('#attrto').val()
-          opts = {method: 'PUT', url: 'users-data'}
-          currdata.forEach(function(elem, ix) {
-            elem[to_change] = newval
-            opts.data = elem
-            if (ix == currdata.length - 1) {
-              opts['success'] = render_fh
-            } else {
-              opts['success'] = console.log
+        $('.users').formhandler({
+          edit: true,
+          add: true,
+          columns: [
+            { name: '*' },
+            {
+              name: password_column,
+              format: function(obj) { return '*'.repeat(obj.value.length) },
+              editable: {input: 'password'}
+            },
+            { name: 'actions', template: $('#action-template').html() }
+          ],
+          actions: [{
+            'reset': function(obj) {
+              var data = {}
+              data[user_key] = obj.row[user_column]
+              return $.ajax(auth_conf.pattern + '?' + forgot_key, {method: 'POST', data: data})
+                .done(function() { obj.notify('Email sent') })
             }
-            $.ajax(opts)
-          })
+          }]
         })
-        render_fh()
-
-
+      $('.auth-rules').formhandler({edit: true, add: true})
       </script>
 
     {% elif current_tab == 'schedule' %}

--- a/gramex/apps/admin2/index.html
+++ b/gramex/apps/admin2/index.html
@@ -128,7 +128,7 @@
                     <input type="text" id="attrto" name="to" class="form-control col-sm-4">
                   </div>
                 </template>
-                <button type="submit" class="btn btn-primary mb-2">Ok</button>
+                <button id='modbtn' type="submit" class="btn btn-primary mb-2" disabled>Ok</button>
               </form>
             </div>
           </div>
@@ -170,6 +170,11 @@
                 $('#attrpattern').val(filters[col])
               }
               $('#attrpattern').change(function() {
+                if ($(this).val()) {
+                  $('#modbtn').prop('disabled', false)
+                } else {
+                  $('#modbtn').prop('disabled', true)
+                }
                 url = g1.url.parse(window.location.href)
                 url.hash = '?' + $('#attrfilter').val() + '~=' + $(this).val()
                 window.location = url.toString()

--- a/gramex/handlers/basehandler.py
+++ b/gramex/handlers/basehandler.py
@@ -589,6 +589,7 @@ class BaseMixin(object):
                 raise HTTPError(BAD_REQUEST, reason=reason)
             self._session_store.dump('otp:' + otp, None)
             self.session['user'] = otp_data['user']
+        # ToDo: apikey = headers.get('X-Gramex-OTP') or self.get_argument('gramex-otp', None)
 
     def set_last_visited(self):
         '''


### PR DESCRIPTION
This PR allows admins to:

1. Add users with passwords, and send welcome emails to them, when the `forgot` key in DBAuth is present.
1. Filter users on any attribute (`pd.Series.str.contains`), and change their attributes.

This currently works only on DBAuth. sanand0 Please take a look.



┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-89)
