### PR TITLE
GRAMEX-119 ⁃ BUG: Ensure that user management with rules works in nested apps

### DIFF
--- a/gramex/apps/admin2/gramexadmin.py
+++ b/gramex/apps/admin2/gramexadmin.py
@@ -96,14 +96,15 @@ class AdminFormHandler(gramex.handlers.FormHandler):
             cls.signup.update(admin_kwargs.pop('signup', {}))
             cls.authhandler, cls.auth_conf, data_conf = get_auth_conf(
                 kwargs.get('admin_kwargs', {}))
+            # When this class is set up for rules, and the authhandler has rules...
             if kwargs.get('rules', False) and cls.auth_conf.kwargs.get('rules', False):
                 # Get the rules for formhandler
                 authhandler = admin_kwargs.get('authhandler', False)
                 if not authhandler:
                     raise ValueError(f'Missing authhandler in url {cls.name}.')
-                # Find the authhandler
+                # Find the authhandler -- even if it's namespace: prefixed
                 for url in gramex.conf['url']:
-                    if url.endswith(authhandler):
+                    if url == authhandler or url.endswith(f':{authhandler}'):
                         break
                 data_conf = gramex.conf['url'].get(
                     url, {}

--- a/gramex/apps/admin2/gramexadmin.py
+++ b/gramex/apps/admin2/gramexadmin.py
@@ -96,13 +96,17 @@ class AdminFormHandler(gramex.handlers.FormHandler):
             cls.signup.update(admin_kwargs.pop('signup', {}))
             cls.authhandler, cls.auth_conf, data_conf = get_auth_conf(
                 kwargs.get('admin_kwargs', {}))
-            if kwargs.get('rules', False) and cls.auth_conf.get('rules', False):
+            if kwargs.get('rules', False) and cls.auth_conf.kwargs.get('rules', False):
                 # Get the rules for formhandler
                 authhandler = admin_kwargs.get('authhandler', False)
                 if not authhandler:
                     raise ValueError(f'Missing authhandler in url {cls.name}.')
+                # Find the authhandler
+                for url in gramex.conf['url']:
+                    if url.endswith(authhandler):
+                        break
                 data_conf = gramex.conf['url'].get(
-                    authhandler, {}
+                    url, {}
                 ).get('kwargs', {}).get('rules', {}).copy()
                 data_conf['id'] = ['selector', 'pattern']
         except ValueError as e:


### PR DESCRIPTION
When an `authhandler:` is specified in an Admin2 user management spec, `AdminFormHandler` picks up the corresponding user attributes in a way that does not work with nested apps.

This PR fixes that.



┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-119)
