### PR TITLE
GRAMEX-125 ⁃ FIX: Don't mention InfluxDB buckets in URLs

### DIFF
--- a/gramex/data.py
+++ b/gramex/data.py
@@ -1532,7 +1532,6 @@ def _influxdb_offset_limit(controls):
 
 
 def _filter_influxdb(url, controls, args, org=None, bucket=None, query=None, **kwargs):
-    args.pop("bucket")
     with _influxdb_client(url, org=org, **kwargs) as db:
         schema = _get_influxdb_schema(db, bucket)
         cols = schema["_fields"] + schema["_tags"] + schema["_measurement"]


### PR DESCRIPTION


┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-125)
