### PR TITLE
GRAMEX-127 ⁃ REQ: Restrict xlrd to version <2

### DIFF
--- a/gramex/release.json
+++ b/gramex/release.json
@@ -79,7 +79,7 @@
     "tornado==5.1.1":             "REQ: Web server",
     "watchdog>=0.8":              "REQ: Monitor file changes",
     "tzlocal":                    "TODO: Why is this required?",
-    "xlrd":                       "REQ: gramex.data.download()"
+    "xlrd<2":                       "REQ: gramex.data.download()"
   },
 
   "pip#": "Packages that can only be installed via pip, not via conda",


### PR DESCRIPTION
Later versions drop support for all file types except .xls
Read more: https://github.com/python-excel/xlrd/blob/master/README.rst



┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-127)
