### PR TITLE
GRAMEX-163 ⁃ ENH: Add login templates to `gramex init minimal`

### DIFF
--- a/gramex/apps/init/minimal/emailauth.template.html
+++ b/gramex/apps/init/minimal/emailauth.template.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Email Auth</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+  <div class="container col-md-6 col-lg-4 col-xl-3">
+    <h1 class="text-center mt-5">Email Auth</h1>
+
+    {%! if error %}
+      <div class="alert alert-danger">
+        <strong>Error</strong>: {{! msg }}
+      </div>
+    {%! end %}
+
+    {%! if email is None and otp is None %}
+      <form method="POST">
+        <input type="hidden" name="_xsrf" value="{{! handler.xsrf_token }}">
+        <p class="row">
+          <label for="user" class="form-label">E-mail</label>
+          <input type="email" class="form-control" name="user" id="user" value="{{! email or '' }}" autofocus>
+        </p>
+        <button type="submit" class="btn btn-primary">Send OTP via E-mail</button>
+      </form>
+      <p class="mt-5"><a href="?user&{{! url_escape(redirect['name']) }}={{! url_escape(redirect['value']) }}">I already have the OTP</a></p>
+    {%! else %}
+      {%! if handler.request.method == 'POST' %}
+        <p>We sent an email to <code>{{! email }}</code> with an OTP and link to log in.</p>
+        <p>Once you receive the OTP, enter it below.</p>
+      {%! end %}
+      <form>
+        <p class="row">
+          <input type="hidden" name="{{! redirect['name'] }}" value="{{! redirect['value'] }}">
+          <input type="hidden" name="user" value="">
+          <input type="hidden" name="_" value="">
+          <label for="password" class="form-label">OTP</label>
+          <input class="form-control" name="password" id="password" value="{{! otp or '' }}" autofocus autocomplete="off">
+        </p>
+        <button type="submit" class="btn btn-primary">Submit OTP</button>
+      </form>
+      <p class="mt-5"><a href="?{{! url_escape(redirect['name']) }}={{! url_escape(redirect['value']) }}">Request new OTP</a></p>
+    {%! end %}
+  </div>
+</body>
+</html>

--- a/gramex/apps/init/minimal/login.template.html
+++ b/gramex/apps/init/minimal/login.template.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>{{ appname }} Login</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="../style.scss">
+</head>
+
+<body class="bg-primary gradient-tc bg-no-repeat text-white">
+  {%! set base = '..' %}
+  {%! set kwargs = handler.kwargs %}
+  {%! try %}{%! set user = kwargs.user.arg %}{%! except %}{%! set user = 'user' %}{%! end %}
+  {%! try %}{%! set password = kwargs.password.arg %}{%! except %}{%! set password = 'password' %}{%! end %}
+  <div class="container d-flex flex-column align-items-center">
+    <div class="card shadow text-dark mx-auto my-4 px-5 py-3 col-md-6">
+      {%! if error %}
+        <div class="alert alert-danger mx-n3">
+          <h1 class="h4">Error logging in</h1>
+          <p>{{! error['error'] }}</p>
+          <div><small><strong>code</strong>: {{! error['code'] }}</small></div>
+        </div>
+      {%! end %}
+      <form method="POST">
+        <div class="form-group">
+          <label for="{{! user }}">Login</label>
+          <input type="text" class="form-control" name="{{! user }}" id="{{! user }}" value="{{! handler.get_argument(user, '') }}" placeholder="Login ID" autofocus required>
+        </div>
+        <div class="form-group">
+          <label for="{{! password  }}">Password</label>
+          <input type="password" class="form-control" name="{{! password }}" id="{{! password }}" placeholder="Password" required>
+        </div>
+        <input type="hidden" name="_xsrf" value="{{! handler.xsrf_token }}">
+        <p><button type="submit" class="btn btn-primary w-100 small">Login</button></p>
+        {%! if kwargs.get('forgot') %}
+          <p class="small"><a href="?{{! kwargs.forgot.key }}">Forgot password</a></p>
+        {%! end %}
+        <div>Default login: alpha (password: alpha)</div>
+      </form>
+    </div><!-- .card -->
+  </div>
+  <script src="../ui/jquery/dist/jquery.min.js"></script>
+  <script src="../ui/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+  {%! if 'hash' in kwargs.get('password', {}) %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-sha256/0.9.0/sha256.min.js"></script>
+    <script>
+      /* eslint-env browser, jquery */
+      /* globals sha256 */
+      // hash the password before submitting
+      $('form').on('submit', function() {
+        var $password = $('#{{! password }}').get(0)
+        $password.value = sha256($password.value)
+      })
+    </script>
+  {%! end %}
+</body>
+
+</html>

--- a/gramex/apps/init/minimal/style.scss
+++ b/gramex/apps/init/minimal/style.scss
@@ -1,0 +1,3 @@
+// See https://gramener.com/gramex/guide/ui/theme/
+
+@import "theme/default";


### PR DESCRIPTION
The minimal app is a little too minimal.
To use AuthHandlers on the IDE, users have to create login templates themselves.
This PR adds login templates for Simple/DBAuth and Email auth to the
miniaml app. Users now just have to select the login template.



┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-163)
