### PR TITLE
GRAMEX-164 ⁃ Create and use Gramex API key

### DIFF
--- a/gramex/handlers/basehandler.py
+++ b/gramex/handlers/basehandler.py
@@ -596,9 +596,9 @@ class BaseMixin(object):
         if otp:
             otp_data = self._session_store.load('otp:' + otp, None)
             if not isinstance(otp_data, dict) or '_t' not in otp_data or 'user' not in otp_data:
-                raise HTTPError(BAD_REQUEST, f'{self.name}: invalid X-Gramex-OTP: {otp}')
+                raise HTTPError(BAD_REQUEST, f'{self.name}: invalid Gramex OTP: {otp}')
             elif otp_data['_t'] < time.time():
-                raise HTTPError(BAD_REQUEST, f'{self.name}: expired X-Gramex-OTP: {otp}')
+                raise HTTPError(BAD_REQUEST, f'{self.name}: expired Gramex OTP: {otp}')
             self._session_store.dump(f'otp:{otp}', None)
             self.session['user'] = otp_data['user']
         # If API Key is specified, set the user from the API key
@@ -606,7 +606,7 @@ class BaseMixin(object):
         if key:
             key_data = self._session_store.load('key:' + key, None)
             if not isinstance(key_data, dict) or 'user' not in key_data:
-                raise HTTPError(BAD_REQUEST, f'{self.name}: invalid X-Gramex-Key: {key}')
+                raise HTTPError(BAD_REQUEST, f'{self.name}: invalid Gramex Key: {key}')
             self.session['user'] = key_data['user']
 
     def set_last_visited(self):

--- a/gramex/handlers/basehandler.py
+++ b/gramex/handlers/basehandler.py
@@ -557,9 +557,9 @@ class BaseMixin(object):
         if getattr(self, '_session', None) is not None:
             self._session_store.dump(self._session['id'], self._session)
 
-    def otp(self, expire=60, prefix='otp'):
+    def otp(self, expire=60, prefix='otp', user=None):
         '''Return one-time password valid for ``expire`` seconds. Use with X-Gramex-OTP header'''
-        user = self.current_user
+        user = self.current_user if user is None else user
         if not user:
             raise HTTPError(UNAUTHORIZED)
         nbits = 16
@@ -567,9 +567,9 @@ class BaseMixin(object):
         self._session_store.dump(f'{prefix}:{otp}', {'user': user, '_t': time.time() + expire})
         return otp
 
-    def apikey(self, expire=1e9):
+    def apikey(self, expire=1e9, user=None):
         '''Return new API Key. To be used with the X-Gramex-Key header.'''
-        return self.otp(expire=expire, prefix='key')
+        return self.otp(expire=expire, prefix='key', user=user)
 
     def override_user(self):
         '''

--- a/gramex/handlers/basehandler.py
+++ b/gramex/handlers/basehandler.py
@@ -564,15 +564,12 @@ class BaseMixin(object):
             raise HTTPError(UNAUTHORIZED)
         nbits = 16
         otp = hexlify(os.urandom(nbits)).decode('ascii')
-        key_data = {'user': user}
-        if expire is not None:
-            key_data['_t'] = time.time() + expire
-        self._session_store.dump(f'{prefix}:{otp}', key_data)
+        self._session_store.dump(f'{prefix}:{otp}', {'user': user, '_t': time.time() + expire})
         return otp
 
-    def apikey(self):
+    def apikey(self, expire=1e9):
         '''Return new API Key. To be used with the X-Gramex-Key header.'''
-        return self.otp(expire=None, prefix='key')
+        return self.otp(expire=expire, prefix='key')
 
     def override_user(self):
         '''
@@ -610,7 +607,7 @@ class BaseMixin(object):
             key_data = self._session_store.load('key:' + key, None)
             if not isinstance(key_data, dict) or 'user' not in key_data:
                 raise HTTPError(BAD_REQUEST, f'{self.name}: invalid X-Gramex-Key: {key}')
-            self.session['user'] = key['user']
+            self.session['user'] = key_data['user']
 
     def set_last_visited(self):
         '''

--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -1559,6 +1559,14 @@ url:
       headers:
         Content-Type: application/json
 
+  auth/apikey:
+    pattern: /auth/apikey
+    handler: FunctionHandler
+    kwargs:
+      function: utils.apikey
+      headers:
+        Content-Type: application/json
+
   auth/authorize:
     pattern: /auth/authorize
     handler: SimpleAuth

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -258,7 +258,8 @@ def otp(handler):
 
 
 def apikey(handler):
-    return json.dumps(handler.apikey())
+    user = {key: val[-1] for key, val in handler.args.items()}
+    return json.dumps(handler.apikey(user=user or None))
 
 
 def increment(handler):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -257,6 +257,10 @@ def otp(handler):
     return json.dumps(handler.otp(expire=expire))
 
 
+def apikey(handler):
+    return json.dumps(handler.apikey())
+
+
 def increment(handler):
     '''
     This function is used to check the cache. Suppose we fetch a page, then


### PR DESCRIPTION
This addresses #434 partially. Calling `handler.apikey(expiry)` generates an API key with the same info as the logged-in user. By default, the key expires after 1e9 seconds ~ 32 years. Any request with a `?gramex-key=<apikey>` or header `X-Gramex-Key: <apikey>` will log in as that user.

Created by radheyakale



┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-164)
