### PR TITLE
GRAMEX-175 ⁃ ENH: Add support for statsmodels.SARIMAX in MLHandler

### DIFF
--- a/gramex/apps/mlhandler/template.html
+++ b/gramex/apps/mlhandler/template.html
@@ -142,7 +142,7 @@ body {
               <div class="col">
                 <label for="transform">Transform:</label>
                 <input class="form-control" id="transform" name="data.transform" type="text"
-                                                  value="{{ handler.store.load('transform', '') }}">
+                                                  value="{{ handler.store.load('built_transform', '') }}">
               </div>
               <div class="col">
                 <label for="metric">Choose a Metric:</label>

--- a/gramex/handlers/mlhandler.py
+++ b/gramex/handlers/mlhandler.py
@@ -13,6 +13,7 @@ from gramex.http import NOT_FOUND, BAD_REQUEST
 from gramex.install import safe_rmtree
 from gramex import cache
 
+import numpy as np
 import pandas as pd
 import joblib
 from sklearn.base import TransformerMixin
@@ -111,6 +112,7 @@ class MLHandler(FormHandler):
             gramex.service.threadpool.submit(
                 cls.model.fit, train, target,
                 model_path=cls.store.model_path, name=cls.name,
+                **cls.store.model_kwargs()
             )
 
     def _parse_multipart_form_data(self):
@@ -171,7 +173,7 @@ class MLHandler(FormHandler):
 
     def _transform(self, data, **kwargs):
         orgdata = self.store.load_data()
-        for col in data:
+        for col in np.intersect1d(data.columns, orgdata.columns):
             data[col] = data[col].astype(orgdata[col].dtype)
         data = self._filtercols(data, **kwargs)
         data = self._filterrows(data, **kwargs)

--- a/gramex/ml_api.py
+++ b/gramex/ml_api.py
@@ -28,7 +28,7 @@ TRANSFORMS = {
     "index_col": None,
 }
 SEARCH_MODULES = {
-    "SklearnModel": [
+    "gramex.ml_api.SklearnModel": [
         "sklearn.linear_model",
         "sklearn.tree",
         "sklearn.ensemble",
@@ -37,11 +37,14 @@ SEARCH_MODULES = {
         "sklearn.neural_network",
         "sklearn.naive_bayes",
     ],
-    "SklearnTransformer": [
+    "gramex.ml_api.SklearnTransformer": [
         "sklearn.decomposition",
         "gramex.ml",
     ],
-    "StatsModel": ["gramex.sm_api"],
+    "gramex.sm_api.StatsModel": [
+        "statsmodels.tsa.api",
+        "statsmodels.tsa.statespace.sarimax"
+    ],
 }
 
 
@@ -278,6 +281,7 @@ class SklearnModel(AbstractModel):
         target_col: Optional[str] = None,
         nums: Optional[List[str]] = None,
         cats: Optional[List[str]] = None,
+        params: Any = None,
         **kwargs,
     ):
         if not isinstance(model, Pipeline) and any([nums, cats]):
@@ -375,7 +379,3 @@ class SklearnTransformer(SklearnModel):
     def _predict(self, X, **kwargs):
         """Sklearn transformers don't have a "predict", they have a "transform"."""
         return self.model.transform(X, **kwargs)
-
-
-class StatsModel(SklearnModel):
-    """A statsmodels model."""

--- a/gramex/ml_api.py
+++ b/gramex/ml_api.py
@@ -207,6 +207,9 @@ class ModelStore(cache.JSONStore):
         self.path = path
         super(ModelStore, self).__init__(op.join(path, "config.json"), *args, **kwargs)
 
+    def model_kwargs(self):
+        return {k: self.load(k) for k in TRANSFORMS}
+
     def load(self, key, default=None):
         if key in ("transform", "model"):
             return super(ModelStore, self).load(key, {})
@@ -292,10 +295,10 @@ class SklearnModel(AbstractModel):
             self.model = model
         self.kwargs = kwargs
 
-    def _fit(self, X, y, **kwargs):
+    def _fit(self, X, y):
         if hasattr(self.model, "partial_fit"):
-            return self.model.partial_fit(X, y, classes=np.unique(y), **kwargs)
-        return self.model.fit(X, y, **kwargs)
+            return self.model.partial_fit(X, y, classes=np.unique(y))
+        return self.model.fit(X, y)
 
     def fit(
         self,
@@ -321,7 +324,7 @@ class SklearnModel(AbstractModel):
         """
         app_log.info("Starting training...")
         try:
-            result = self._fit(X, y, **kwargs)
+            result = self._fit(X, y)
             app_log.info("Done training...")
         except Exception as exc:
             app_log.exception(exc)

--- a/gramex/sm_api.py
+++ b/gramex/sm_api.py
@@ -2,14 +2,19 @@ import pandas as pd
 import numpy as np
 from gramex.config import app_log
 from statsmodels import api as sm
+from statsmodels.tsa.statespace.sarimax import SARIMAXResultsWrapper
 from sklearn.metrics import mean_absolute_error
+from gramex.ml_api import AbstractModel
 
 
-class SARIMAX(object):
-
-    def __init__(self, order=(1, 0, 0), **kwargs):
-        self.stl_kwargs = kwargs.pop('stl', False)
-        self.params = kwargs
+class StatsModel(AbstractModel):
+    def __init__(self, mclass, params, **kwargs):
+        self.stl_kwargs = kwargs.pop("stl", False)
+        if isinstance(mclass, SARIMAXResultsWrapper):
+            self.res = mclass
+        self.mclass = mclass
+        self.params = params
+        self.kwargs = kwargs
 
     def _timestamp_data(self, data, index_col):
         if data.index.name != index_col:
@@ -21,11 +26,13 @@ class SARIMAX(object):
     def _get_stl(self, endog):
         if not self.stl_kwargs:
             return endog
-        stl_components = self.stl_kwargs.get('components', [])
-        if stl_components and (not set(stl_components) < {'seasonal', 'trend', 'resid'}):
-            app_log.warning(f'Invalid STL components {stl_components}. Ignoring STL.')
+        stl_components = self.stl_kwargs.get("components", [])
+        if stl_components and (
+            not set(stl_components) < {"seasonal", "trend", "resid"}
+        ):
+            app_log.warning(f"Invalid STL components {stl_components}. Ignoring STL.")
             return endog
-        kwargs = self.stl_kwargs.get('kwargs', {})
+        kwargs = self.stl_kwargs.get("kwargs", {})
 
         app_log.critical(endog.index.freq)
         app_log.critical(endog.index.dtype)
@@ -35,25 +42,32 @@ class SARIMAX(object):
             result += getattr(decomposed, comp)
         return pd.Series(result, index=endog.index)
 
-    def fit(self, X, y=None, index_col=None, target_col=None):
+    def fit(
+        self, X, y=None, model_path=None, name=None, index_col=None, target_col=None
+    ):
         """Only a dataframe is accepted. Index and target columns are both expected to be in it."""
         params = self.params.copy()
+        X = self._timestamp_data(X, index_col)
         if y is None:
             y = X[target_col]
             X = X.drop([target_col], axis=1)
+        else:
+            y.index = X.index
         endog = y
         exog = X.drop([target_col], axis=1) if target_col in X else X
         params["exog"] = exog
-        endog = self._timestamp_data(endog, index_col)
         endog.index.freq = self.params.pop("freq", pd.infer_freq(endog.index))
         endog = self._get_stl(endog)
         exog.index = endog.index
         missing = self.params.pop("missing", "drop")
-        self.model = sm.tsa.SARIMAX(endog, missing=missing, **params)
+        self.model = self.mclass(endog, missing=missing, **params)
         self.res = self.model.fit()
+        self.res.save(model_path)
         return self.res.summary().as_html()
 
-    def predict(self, data, index_col=None, start=None, end=None, target_col=None, **kwargs):
+    def predict(
+        self, data, index_col=None, start=None, end=None, target_col=None, **kwargs
+    ):
         data = self._timestamp_data(data, index_col)
         start = data.index.min() if start is None else start
         end = data.index.max() if end is None else end
@@ -62,8 +76,8 @@ class SARIMAX(object):
             exog = data.drop(target_col, axis=1)
         return self.res.predict(start, end, exog=exog, **kwargs)
 
-    def score(self, data, y_pred, score_col):
-        y_true = data[score_col].values
+    def score(self, X, y_true, **kwargs):
+        y_pred = self.res.predict(start=X.index.min(), end=X.index.max(), exog=X)
         y_true, y_pred = (
             pd.DataFrame({"y_true": y_true, "y_pred": y_pred.values}).dropna().values.T
         )
@@ -77,3 +91,9 @@ class SARIMAX(object):
 
     def get_params(self):
         return self.params
+
+    def get_attributes(self):
+        result = getattr(self, "res", False)
+        if not result:
+            return {}
+        return result.summary().as_html()

--- a/gramex/sm_api.py
+++ b/gramex/sm_api.py
@@ -43,7 +43,8 @@ class StatsModel(AbstractModel):
         return pd.Series(result, index=endog.index)
 
     def fit(
-        self, X, y=None, model_path=None, name=None, index_col=None, target_col=None
+        self, X, y=None, model_path=None, name=None, index_col=None, target_col=None,
+        **kwargs
     ):
         """Only a dataframe is accepted. Index and target columns are both expected to be in it."""
         params = self.params.copy()

--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -1248,6 +1248,8 @@ url:
     kwargs:
       model:
         class: SARIMAX
+        params:
+          order: [7, 1, 0]
       xsrf_cookies: false
 
   capture:

--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -1241,6 +1241,15 @@ url:
           n_components: 2
       xsrf_cookies: false
 
+  # statsmodels
+  mlhandler/sarimax:
+    pattern: /sarimax
+    handler: MLHandler
+    kwargs:
+      model:
+        class: SARIMAX
+      xsrf_cookies: false
+
   capture:
     pattern: /capture
     handler: CaptureHandler

--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -1191,6 +1191,19 @@ url:
         cats: [species]
       xsrf_cookies: false
 
+  mlhandler/pipeline:
+    pattern: /mlpipe
+    handler: MLHandler
+    kwargs:
+      data:
+        url: $YAMLPATH/actors.csv
+      model:
+        class: DecisionTreeRegressor
+        target_col: rating
+        cats: [category]
+        exclude: [name]
+      xsrf_cookies: false
+
   mlhandler/nopath:
     pattern: /mlnopath
     handler: MLHandler

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,3 +13,4 @@ sphinx_rtd_theme      # For documentation
 testfixtures          # For logcapture
 typing_extensions     # For OpenAPIHandler annotation testing
 websocket-client      # For websocket testing
+statsmodels           # For sm_api.StatsModels

--- a/tests/test_mlhandler.py
+++ b/tests/test_mlhandler.py
@@ -1,5 +1,6 @@
 from io import BytesIO, StringIO
 import os
+from unittest import skipUnless
 
 import joblib
 import gramex
@@ -16,10 +17,36 @@ from sklearn.compose import ColumnTransformer
 from sklearn.tree import DecisionTreeClassifier
 
 from . import TestGramex, folder, tempfiles
+try:
+    from statsmodels.datasets.interest_inflation import load as infl_load
+    STATSMODELS_INSTALLED = True
+except ImportError:
+    STATSMODELS_INSTALLED = False
+
+
 op = os.path
 
 
-class TestMLHandler(TestGramex):
+@skipUnless(STATSMODELS_INSTALLED, "Please install statsmodels to run these tests.")
+class TestStatsmodels(TestGramex):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root = op.join(gramex.config.variables['GRAMEXDATA'], 'apps', 'mlhandler')
+        paths = [op.join(cls.root, f) for f in [
+            'mlhandler-sarimax/config.json',
+            'mlhandler-sarimax/data.h5',
+            'mlhandler-sarimax/mlhandler-sarimax.pkl',
+        ]]
+        for p in paths:
+            tempfiles[p] = p
+
+    def test_sarimax(self):
+        data = infl_load().data
+        resp = self.get('/sarimax')
+
+
+class TestSklearn(TestGramex):
     ACC_TOL = 0.95
 
     @classmethod


### PR DESCRIPTION
Post https://github.com/gramener/gramex/pull/507, this version of the statsmodels API is available via the
wrapper classes for MLHandler, instead of being in the handler itself.



┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-175)
