### PR TITLE
GRAMEX-187 ⁃ smaller image with correct gramex version installed

### DIFF
--- a/pkg/docker-py3/Dockerfile.tmpl
+++ b/pkg/docker-py3/Dockerfile.tmpl
@@ -6,15 +6,21 @@ LABEL version="{{ version }}"
 LABEL maintainer="{{ author_email }}"
 
 # Install system requirements. The ORDER of runs is critical. Keep them exactly in this order
-RUN apt update && apt install -y pandoc
-RUN pip install --upgrade pip orderedattrdict tornado
-RUN conda install -c conda-forge -c gramener gramex -y
-RUN apt -y install gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+RUN apt -qqy --allow-releaseinfo-change update --fix-missing && \
+    apt install -qqy pandoc curl
+RUN apt -qqy install gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
     libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
     libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 \
     libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 \
     libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-    fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils
+    fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
+    python3-dev default-libmysqlclient-dev build-essential
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt update --fix-missing -qqy && \
+    apt install -qqy nodejs --fix-missing && \
+    pip install -q psycopg2-binary==2.9.3 \
+                mysqlclient gramex=="{{ version }}" \
+    gramex setup --all
 
 # Expose port 9988 by default. It can be overridden, e.g. via -p 3333:3333
 EXPOSE 9988


### PR DESCRIPTION
Added some more necessary libraries needed to run gramex properly:


* `node` installation is necessary
* `gramex setup --all` is necessary

Next Step:


* Cut the image a little smaller by `apt -autoremove (if any)`
* Build docker image on every new release of gramex.
  by adding new stage:

```yaml
build_image:
  - stage:  build_image
    only:
      - tags
    # all commands to build the image
```

to the pipeline



┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-187)
