### PR TITLE
GRAMEX-195 ⁃ FIX: Pipelines support iter=True

### DIFF
--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -383,8 +383,19 @@ url:
       function:
         - { name: x, function: '"--"' }
         - { name: n, function: 2}
-        - { function: (x + handler.request.path) * n }
-
+        - (x + handler.request.path) * n
+  func/pipeline-number:
+    pattern: /func/pipeline-number
+    handler: FunctionHandler
+    kwargs:
+      function:
+        - 2
+  func/pipeline-iterable:
+    pattern: /func/pipeline-iterable
+    handler: FunctionHandler
+    kwargs:
+      function:
+        - [3, x, null, false]   # Returns [3, "x", false]
   # TestPyNode
   pynode/run:
     pattern: /pynode/run

--- a/tests/test_functionhandler.py
+++ b/tests/test_functionhandler.py
@@ -87,6 +87,9 @@ class TestFunctionHandler(TestGramex):
         eq_(execs['name'].iloc[0], 'url:func/pipeline')
         eq_(execs['error'].iloc[0], None)
 
+        self.check('/func/pipeline-number', text='2')
+        self.check('/func/pipeline-iterable', text='[3,"x",false]')
+
 
 class TestWrapper(TestGramex):
     def test_config_kwargs(self):


### PR DESCRIPTION
build_transform() compiles a string into a function.
build_transform(iter=True) forces the function to return an array.

Last week, we modified build_transform() to compile pipelines.
(Pipelines = ARRAYS of functions.)
But it didn't support iter=True.
It always returned the value as-is.
(Why? I didn't think it would be needed.)

But there's a reason why iter=True is there in build_transform.
FunctionHandler requires iterables.
This lets it render functions that yield values one by one, slowly.
So, build_transform() needs to support iter=True even for
ARRAYS of functions, i.e. pipelines.

Now, build_transform() now supports iter=True for pipelines.
It just returns the output as an array (or as-is, if it's a generator.)


This apart, there's another change.
Earlier, pipeline steps had to be dicts with a `function:` key, like this:

```yaml
function:
    - {name: x, function: random.randint(0, 100)}
    - {name: y, function: random.randint(0, 100)}
    - {function: x + y}
```

Note the last line. `{function: x + y}`.
Ideally, we should be able to write it like `x + y`.

This commit allows that.


┆Issue is synchronized with this [Jira Bug](https://gramenertech.atlassian.net/browse/GRAMEX-195)
