### PR TITLE
DEP: rmarkdown deprecated in FileHandler transforms

### DIFF
--- a/gramex/transforms/template.py
+++ b/gramex/transforms/template.py
@@ -101,6 +101,7 @@ def rmarkdown(content, handler=None, **kwargs):
 
     !!! Deprecated
         Support for R is being phased out in favor of Python ML libraries.
+        It will be removed by Gramex 1.82 (Aug 2022)
 
     This can be used as a transform in FileHandler:
 
@@ -120,7 +121,7 @@ def rmarkdown(content, handler=None, **kwargs):
     import gramex.services
     from gramex.config import app_log
 
-    app_log.warning('rmarkdown: transform deprecated')
+    app_log.warning('rmarkdown: transform deprecated, expires v1.82 Aug 2022')
     rmdfilepath = str(handler.file)
     htmlpath = yield gramex.services.info.threadpool.submit(
         gramex.ml.r,

--- a/gramex/transforms/template.py
+++ b/gramex/transforms/template.py
@@ -99,6 +99,9 @@ def vue(content, handler):
 def rmarkdown(content, handler=None, **kwargs):
     '''Render an Rmarkdown file as HTML in a FileHandler.
 
+    !!! Deprecated
+        Support for R is being phased out in favor of Python ML libraries.
+
     This can be used as a transform in FileHandler:
 
     ```yaml
@@ -115,7 +118,9 @@ def rmarkdown(content, handler=None, **kwargs):
     '''
     import gramex.ml
     import gramex.services
+    from gramex.config import app_log
 
+    app_log.warning('rmarkdown: transform deprecated')
     rmdfilepath = str(handler.file)
     htmlpath = yield gramex.services.info.threadpool.submit(
         gramex.ml.r,

--- a/tests/test_filehandler.py
+++ b/tests/test_filehandler.py
@@ -6,7 +6,6 @@ import requests
 import markdown
 from gramex.http import OK, FORBIDDEN, METHOD_NOT_ALLOWED
 from orderedattrdict import AttrDict
-from gramex.ml import r
 from gramex.transforms import rmarkdown
 from nose.tools import ok_, eq_
 from nose.plugins.skip import SkipTest
@@ -164,10 +163,6 @@ class TestFileHandler(TestGramex):
             self.check('/dir/transform/markdown.md', text=markdown.markdown(f.read()))
 
     def test_rmarkdown(self):
-        # rmarkdown must be installed
-        ok_(r('"rmarkdown" %in% installed.packages()')[0],
-            'rmarkdown must be installed. Run conda install -c r r-rmarkdown')
-
         def _callback(f):
             f = f.result()
             return f
@@ -178,7 +173,7 @@ class TestFileHandler(TestGramex):
         try:
             self.check('/dir/transform/rmarkdown.Rmd', text=result, timeout=30)
         except AssertionError:
-            raise SkipTest('TODO: Once NumPy & rpy2 work together, remove this SkipTest. #259')
+            raise SkipTest('rmarkdown deprecated')
         htmlpath = str(server.info.folder / 'dir/rmarkdown.html')
         tempfiles[htmlpath] = htmlpath
 


### PR DESCRIPTION
RMarkdown is rarely used with Gramex. It is very hard to support.
The underlying packages have several installation issues and
compatibility issues with NumPy. So we're phasing out support.