### PR TITLE
TST: If PhantomJS is not installed, skip capture tests

### DIFF
--- a/tests/test_capturehandler.py
+++ b/tests/test_capturehandler.py
@@ -83,6 +83,7 @@ class TestCaptureHandler(TestGramex):
 
     @classmethod
     def setupClass(cls):
+        # If PhantomJS is not installed, skip the entire test class
         if not paths['phantomjs']:
             raise SkipTest('phantomjs is not installed')
         cls.capture = get_capture('default', port=9402)

--- a/tests/test_capturehandler.py
+++ b/tests/test_capturehandler.py
@@ -7,6 +7,7 @@ import logging
 from PIL import Image
 from pptx import Presentation
 from pptx.util import Pt
+from nose.plugins.skip import SkipTest
 from nose.tools import eq_, ok_
 from pdfminer.layout import LAParams
 from pdfminer.pdfpage import PDFPage
@@ -70,7 +71,6 @@ def get_layout_elements(content):
 
 
 def test_dependencies():
-    assert paths['phantomjs'], 'phantomjs is not installed'
     assert paths['node'], 'node is not installed'
 
 
@@ -83,6 +83,8 @@ class TestCaptureHandler(TestGramex):
 
     @classmethod
     def setupClass(cls):
+        if not paths['phantomjs']:
+            raise SkipTest('phantomjs is not installed')
         cls.capture = get_capture('default', port=9402)
         cls.folder = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
PhantomJS is deprecated. There's no point testing it any more.
If PhantomJS is not installed, the tests should not fail.