### PR TITLE
ENH: Allow revoking OTP and API keys

### DIFF
--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -1629,6 +1629,12 @@ url:
       headers:
         Content-Type: application/json
 
+  auth/revoke:
+    pattern: /auth/revoke
+    handler: FunctionHandler
+    kwargs:
+      function: utils.revoke
+
   auth/authorize:
     pattern: /auth/authorize
     handler: SimpleAuth

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -297,6 +297,14 @@ class TestSimpleAuth(AuthBase, LoginMixin, LoginFailureMixin):
             r = self.session.get(server.base_url + '/auth/session', params={'gramex-otp': otp})
             eq_(r.status_code, BAD_REQUEST)
 
+        # Revoke an OTP
+        self.session.get(server.base_url + f'/auth/revoke?otp={otp1}')
+        # Fetching the session info raises a HTTP 400 because of the invalid OTP
+        r = self.session.get(server.base_url + '/auth/session', params={'gramex-otp': otp1})
+        eq_(r.status_code, 400)
+        r = self.session.get(server.base_url + '/auth/session', headers={'X-Gramex-OTP': otp1})
+        eq_(r.status_code, 400)
+
     def test_apikey(self):
         # Get an API key as the user "alpha"
         self.session = requests.Session()
@@ -327,6 +335,14 @@ class TestSimpleAuth(AuthBase, LoginMixin, LoginFailureMixin):
         check_key({'user': 'new', 'role': 'x'}, params={'gramex-key': apikey})
         # A new session is not logged in by default, but setting X-Gramex-Key: header logs user in
         check_key({'user': 'new', 'role': 'x'}, headers={'X-Gramex-Key': apikey})
+
+        # Revoke an API key
+        self.session.get(server.base_url + f'/auth/revoke?key={apikey}')
+        # Fetching the session info raises a HTTP 400 because of the invalid key
+        r = self.session.get(server.base_url + '/auth/session', params={'gramex-key': apikey})
+        eq_(r.status_code, 400)
+        r = self.session.get(server.base_url + '/auth/session', headers={'X-Gramex-Key': apikey})
+        eq_(r.status_code, 400)
 
     def test_authorize(self):
         # If an Auth handler has an auth:, the auth: is ignored. Auth handlers are always open

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -262,6 +262,13 @@ def apikey(handler):
     return json.dumps(handler.apikey(user=user or None))
 
 
+def revoke(handler):
+    if 'otp' in handler.args:
+        handler.revoke_otp(handler.args['otp'][-1])
+    elif 'key' in handler.args:
+        handler.revoke_apikey(handler.args['key'][-1])
+
+
 def increment(handler):
     '''
     This function is used to check the cache. Suppose we fetch a page, then


### PR DESCRIPTION
handler.revoke_otp(otp) revokes the OTP.
handler.revoke_apikey(key) revokes the API key.