### PR TITLE
FIX: storelocations.otp purge now works

### DIFF
--- a/gramex/gramex.yaml
+++ b/gramex/gramex.yaml
@@ -315,12 +315,7 @@ schedule:
 
     # Every day and on startup, purge expired keys from storelocations.otp
     gramex_purge_otp:
-        function: >
-          gramex.data.delete(
-              **gramex.service.storelocations.otp,
-              id=['token'],
-              args={'expire<': [time.time()]},
-          )
+        function: gramex.services._storelocations_purge()
         startup: true
         minutes: 1
         hours: 0

--- a/gramex/services/__init__.py
+++ b/gramex/services/__init__.py
@@ -553,6 +553,15 @@ def storelocations(conf: dict) -> None:
         gramex.data.alter(**subconf)
 
 
+def _storelocations_purge() -> None:
+    import time
+    gramex.data.delete(
+        **gramex.service.storelocations.otp,
+        id=['token'],
+        args={'expire<': [time.time()]},
+    )
+
+
 class GramexApp(tornado.web.Application):
     def log_request(self, handler):
         # BaseHandler defines a a custom log format. If that's present, use it.


### PR DESCRIPTION
storelocations.otp needs to be purged of expired keys.
This was handled by a daily schedule.
But this schedule uses time.time() to get the current time.
That requires the time module to be imported first.
(Gramex transforms auto-import only modules at the start.)

So, refactor the purge code into a function.