### PR TITLE
Dissolve a for loop that concatenate strings to str.join

### DIFF
--- a/tests/functionutils.py
+++ b/tests/functionutils.py
@@ -33,9 +33,7 @@ def multilist(items: List[int], start: float) -> float:
 
 @handler
 def strtotal(*items: str) -> str:
-    s = ''
-    for i in items:
-        s += i
+    s = ''.join([i for i in items])
     return s
 
 


### PR DESCRIPTION
Line 37, 38 of the file `tests/functionutils.py` uses a loop to concatenate strings. 
I think the more pythonic way is to use `str.join` instead. 
On the performance level, `str.join` is much faster if the list is very long.