### PR TITLE
FIX: FormHandler converts date values before comparing

### DIFF
--- a/gramex/data.py
+++ b/gramex/data.py
@@ -1109,9 +1109,8 @@ def _filter_frame_col(data, key, col, op, vals, meta):
     return data
 
 
-# Treat SQL type datetime as str when converting URL arguments to values.
-# Don't try to convert ?date=2022-01-01 to datetime(2022, 1, 1).
-_sql_types = {datetime: str}
+# If a column has a datetime type, use Pandas to convert strings to datetime values
+_sql_types = {datetime: pd.to_datetime}
 
 
 def _filter_db_col(query, method, key, col, op, vals, column, conv, meta):

--- a/testlib/test_data.py
+++ b/testlib/test_data.py
@@ -371,8 +371,8 @@ class TestFilter(unittest.TestCase):
 
     def check_filter_dates(self, dbname, url):
         self.db.add(dbname)
-        df = self.dates[self.dates['date'] > '2018-02-01 01:00:00']
-        dff = gramex.data.filter(url=url, table='dates', args={'date>': ['2018-02-01 01:00:00']})
+        df = self.dates[self.dates['date'] > pd.to_datetime('2018-01-15 01:00:00')]
+        dff = gramex.data.filter(url=url, table='dates', args={'date>': ['15 Jan 2018 01:00:00']})
         eqframe(dff, df)
 
     def test_mysql(self):


### PR DESCRIPTION
Earlier, comparison was via a string. That works for YYYY-MM-DD formats but not for other formats.