### PR TITLE
ENH: API ratelimit available for all handlers. Fixes #632

### DIFF
--- a/gramex/gramex.yaml
+++ b/gramex/gramex.yaml
@@ -276,14 +276,39 @@ app:
     # Save in a JSON store
     type: json
     path: $GRAMEXDATA/session.json
-    # Flush every 5 seconds
+    # Flush every 5 seconds. Clear expired sessions every hour
     flush: 5
-    # Clear expired sessions every hour
     purge: 3600
     # Cookies expire after 31 days
     expiry: 31
     # Browsers cannot use JS to access session cookie. Only HTTP access allowed, for security
     httponly: true
+
+  # Configure how rate limiting works.
+  ratelimit:
+    # Save in a JSON store
+    type: json
+    path: $GRAMEXDATA/ratelimit.json
+    # Flush every 30 seconds. Clear expired sessions every hour
+    flush: 30
+    purge: 3600
+    # These can be used in keys as pre-defined functions
+    keys:
+      hourly:
+        function: "pd.Timestamp.utcnow().strftime('%Y-%m-%d %H')"
+        expiry: "int((pd.Timestamp.utcnow().ceil(freq='H') - pd.Timestamp.utcnow()).total_seconds())"
+      daily:
+        function: "pd.Timestamp.utcnow().strftime('%Y-%m-%d')"
+        expiry: "int((pd.Timestamp.utcnow().normalize() + pd.Timedelta(days=1) - pd.Timestamp.utcnow()).total_seconds())"
+      weekly:
+        function: "pd.Timestamp.utcnow().strftime('%Y %U')"
+        expiry: "int((pd.Timestamp.utcnow().normalize() + pd.Timedelta(days=7) - pd.Timestamp.utcnow()).total_seconds())"
+      monthly:
+        function: "pd.Timestamp.utcnow().strftime('%Y-%m')"
+        expiry: "int((pd.Timestamp.utcnow().normalize() + pd.offsets.MonthBegin() - pd.Timestamp.utcnow()).total_seconds())"
+      yearly:
+        function: "pd.Timestamp.utcnow().strftime('%Y')"
+        expiry: "int((pd.Timestamp.utcnow().normalize() + pd.offsets.YearBegin() - pd.Timestamp.utcnow()).total_seconds())"
 
 # The storelocations: section defines where Gramex stores its data.
 storelocations:

--- a/gramex/handlers/basehandler.py
+++ b/gramex/handlers/basehandler.py
@@ -111,8 +111,14 @@ class BaseMixin:
         return kwargs
 
     @classmethod
-    def get_list(cls, val: Union[list, tuple, str], key: str = '', eg: str = '', caps=True) -> set:
+    def get_list(
+        cls, val: Union[list, tuple, str], key: str = '', eg: str = '', caps: bool = True
+    ) -> set:
         '''Split comma-separated values into a set.
+
+        Process kwargs that can be a comma-separated string or a list,
+        like BaseMixin's `methods:`, `cors.origins`, `cors.methods`, `cors.headers`,
+        `ratelimit.keys`, etc.
 
         Examples:
             >>> get_list('GET, PUT') == {'GET', 'PUT'}
@@ -120,8 +126,7 @@ class BaseMixin:
             >>> get_list([' GET ,  PUT', ' ,POST, ']) == {'GET', 'PUT', 'POST'}
 
         Parameters:
-            val: Input to split. If val is not str/list/tuple, raise
-                ValueError("url.{key} invalid. e.g. {eg}")
+            val: Input to split. If val is not str/list/tuple, raise `ValueError`
             key: `url:` key to display in error message
             eg: Example values to display in error message
             caps: True to convert values to uppercase

--- a/gramex/transforms/__init__.py
+++ b/gramex/transforms/__init__.py
@@ -3,7 +3,7 @@
 from .auth import ensure_single_session
 from .template import template, sass, scss, ts, vue
 from .transforms import build_transform, build_pipeline, build_log_info, condition, flattener, once
-from .transforms import handler, Header
+from .transforms import handler, handler_expr, Header
 
 # Import common libraries with their popular abbreviations.
 # This lets build_transform() to use, for e.g., `pd.concat()` instead of `pandas.concat()`.
@@ -24,6 +24,7 @@ __all__ = [
     'flattener',
     'once',
     'handler',
+    'handler_expr',
     'Header',
     'pd',
     'np',

--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -170,6 +170,35 @@ url:
       headers:
         Content-Type: application/json
 
+  ratelimit/a:
+    pattern: /ratelimit/a
+    handler: FunctionHandler
+    kwargs:
+      function: 1 / float(handler.get_arg('n', 1))
+      ratelimit: &RATELIMIT_POOL1
+        pool: pool1
+        keys: [env.HOME, daily, user]
+        limit: 3
+
+  ratelimit/b:
+    pattern: /ratelimit/b
+    handler: FunctionHandler
+    kwargs:
+      function: 1 / float(handler.get_arg('n', 1))
+      ratelimit:
+        <<: *RATELIMIT_POOL1
+
+  ratelimit/reset:
+    pattern: /ratelimit/reset
+    handler: FunctionHandler
+    kwargs:
+      function: >
+        gramex.handlers.BaseHandler.reset_ratelimit(
+          'pool1',
+          [os.environ.get('HOME', ''), pd.Timestamp.utcnow().strftime('%Y-%m-%d'), handler.get_arg('user', '')],
+          0,
+        )
+
   # TestFunctionHandler
   func/args:
     pattern: /func/args

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,12 +1,18 @@
+import json
 import os
 import requests
+import pandas as pd
+import gramex
+import gramex.handlers
 from . import server
 from . import TestGramex
-from nose.tools import eq_, ok_
+from orderedattrdict import AttrDict
+from nose.tools import eq_, ok_, assert_raises
+from tornado.web import create_signed_value
 from urllib.request import urlopen
 from urllib.error import HTTPError
 from gramex.services import info
-from gramex.http import OK, NOT_FOUND, INTERNAL_SERVER_ERROR, FORBIDDEN
+from gramex.http import OK, NOT_FOUND, INTERNAL_SERVER_ERROR, FORBIDDEN, TOO_MANY_REQUESTS
 
 
 class TestURLPriority(TestGramex):
@@ -214,3 +220,157 @@ class TestConfig(TestGramex):
         r = self.check('/appconfig').json()
         eq_(r['url']['appconfig']['pattern'], '/appconfig')
         eq_(r['url']['appconfig']['kwargs']['headers'], {'Content-Type': 'application/json'})
+
+
+class TestRateLimit(TestGramex):
+    def test_setup(self):
+        def setup(ratelimit=None, ratelimit_app_conf=None, base=gramex.handlers.BaseHandler):
+            '''Run setup_ratelimit() on a new subclass of cls'''
+            class_vars = {
+                'conf': AttrDict(pattern='/test'),
+                'name': 'test',
+                '_on_init_methods': [],
+                '_on_finish_methods': [],
+            }
+            handler = type(base.__name__, (base,), class_vars)
+            handler.setup_ratelimit(ratelimit, ratelimit_app_conf)
+            return handler
+
+        # ratelimit: is optional
+        setup(None, None)
+
+        # ratelimit: requires app.ratelimit
+        with assert_raises(ValueError) as cm:
+            setup({}, None)
+        eq_(cm.exception.args[0], "url:test.ratelimit: no app.ratelimit defined")
+
+        # ratelimit.keys required
+        with assert_raises(ValueError) as cm:
+            setup({}, {})
+        eq_(cm.exception.args[0], 'url:test.ratelimit.keys: missing')
+
+        # ratelimit.limit required
+        with assert_raises(ValueError) as cm:
+            setup({'keys': 'daily'}, {})
+        eq_(cm.exception.args[0], 'url:test.ratelimit.limit: missing')
+
+        # ratelimit.keys strings MUST be predefined
+        with assert_raises(ValueError) as cm:
+            setup({'keys': 'daily', 'limit': 5}, {})
+        eq_(cm.exception.args[0], 'url:test.ratelimit.keys: daily is unknown')
+
+        # ratelimit.keys strings MUST be str/list
+        with assert_raises(ValueError) as cm:
+            setup({'keys': 0, 'limit': 5}, {})
+        eq_(cm.exception.args[0], 'url:test.ratelimit.keys: needs dict list, not 0')
+
+        # ratelimit.keys: invalid function compilation directly raises exceptions, e.g. SyntaxError
+        with assert_raises(SyntaxError):
+            setup({'keys': [{'function': ';$@'}], 'limit': 5}, {})
+
+        # ratelimit.keys dicts need a function:
+        with assert_raises(ValueError) as cm:
+            setup({'keys': {'x': 0}, 'limit': 5}, {})
+        eq_(cm.exception.args[0], "url:test.ratelimit.keys: {'x': 0} has no function:")
+        with assert_raises(ValueError) as cm:
+            setup({'keys': [{'x': 0}], 'limit': 5}, {})
+        eq_(cm.exception.args[0], "url:test.ratelimit.keys: {'x': 0} has no function:")
+
+        # ratelimit.keys can be a predefined key string
+        for key in ('hourly', 'daily', 'weekly', 'monthly', 'yearly', 'user'):
+            ok_(setup({'keys': key, 'limit': 5}, gramex.conf.app.ratelimit)._ratelimit.store)
+
+        # ratelimit.keys can be a dict with a function. Defines a single key
+        ok_(setup({'keys': {'function': '0'}, 'limit': 5}, gramex.conf.app.ratelimit))
+
+        # ratelimit.keys can be a comma-separated string
+        cls = setup({'keys': 'daily, user', 'limit': 5}, gramex.conf.app.ratelimit)
+        eq_(len(cls._ratelimit.key_fn), 2)
+
+        # ratelimit.keys can be an array of strings
+        cls = setup({'keys': ['daily', 'user'], 'limit': 5}, gramex.conf.app.ratelimit)
+        eq_(len(cls._ratelimit.key_fn), 2)
+
+        # ratelimit.limit must be a number
+        with assert_raises(ValueError) as cm:
+            setup({'keys': 'daily', 'limit': 'x'}, gramex.conf.app.ratelimit)
+        eq_(cm.exception.args[0], "url:test.ratelimit.limit: needs {'function': number}, not x")
+
+        # ratelimit.limit can be a function
+        cls = setup({'keys': 'user', 'limit': {'function': '5'}}, gramex.conf.app.ratelimit)
+        eq_(cls._ratelimit.limit_fn(None), 5)
+
+        # EVERY handler supports rate-limiting via `ratelimit:`
+        for base in (
+            gramex.handlers.FunctionHandler,
+            gramex.handlers.FormHandler,
+            gramex.handlers.FileHandler,
+            gramex.handlers.DriveHandler,
+        ):
+            cls = setup({'keys': 'daily, user', 'limit': 5}, gramex.conf.app.ratelimit, base)
+            ok_(issubclass(cls, base))
+
+        # ratelimit.keys return the expected values
+        all_keys = ['hourly', 'daily', 'weekly', 'monthly', 'yearly', 'user']
+        cls = setup({'keys': all_keys, 'limit': 5}, gramex.conf.app.ratelimit)
+        key_fn = dict(zip(all_keys, cls._ratelimit.key_fn))
+        handler = AttrDict(current_user=AttrDict(id='a@b'))
+        eq_(key_fn['hourly']['function'](handler), pd.Timestamp.utcnow().strftime('%Y-%m-%d %H'))
+        eq_(key_fn['daily']['function'](handler), pd.Timestamp.utcnow().strftime('%Y-%m-%d'))
+        eq_(key_fn['weekly']['function'](handler), pd.Timestamp.utcnow().strftime('%Y %U'))
+        eq_(key_fn['monthly']['function'](handler), pd.Timestamp.utcnow().strftime('%Y-%m'))
+        eq_(key_fn['yearly']['function'](handler), pd.Timestamp.utcnow().strftime('%Y'))
+        eq_(key_fn['user']['function'](handler), 'a@b')
+
+    def test_ratelimit(self):
+        def check(url, user, limit, remaining, code=OK):
+            # If user= is specified, send an {'id': user} object via headers
+            headers = {}
+            if user is not None:
+                cookie_secret = gramex.service.app.settings['cookie_secret']
+                sign = create_signed_value(cookie_secret, 'user', json.dumps({'id': user}))
+                headers['X-Gramex-User'] = sign
+
+            # Check the status code and X-Ratelimit-* headers
+            r = self.check(url, code=code, request_headers=headers)
+            if code in (OK, TOO_MANY_REQUESTS):
+                eq_(r.headers['X-Ratelimit-Limit'], str(limit))
+                eq_(r.headers['X-Ratelimit-Remaining'], str(remaining))
+                # Check expiry time to plus/minus 2 seconds.
+                # NOTE: This test may fail if running exactly at UTC midnight
+                eod = pd.Timestamp.utcnow().normalize() + pd.Timedelta(days=1)
+                expiry = int((eod - pd.Timestamp.utcnow()).total_seconds())
+                ok_(expiry - 2 <= int(r.headers['X-Ratelimit-Reset']) <= expiry + 2)
+                # Retry-After header should be sent only for
+                if code == TOO_MANY_REQUESTS:
+                    eq_(r.headers['Retry-After'], r.headers['X-Ratelimit-Reset'])
+                else:
+                    ok_('Retry-After' not in r.headers)
+            else:
+                # No headers sent for HTTP errors
+                ok_('X-Ratelimit-Limit' not in r.headers)
+                ok_('X-Ratelimit-Remaining' not in r.headers)
+                ok_('X-Ratelimit-Reset' not in r.headers)
+                ok_('Retry-After' not in r.headers)
+
+        # Reset usage count for all users before beginning the test
+        self.check('/ratelimit/reset')
+        self.check('/ratelimit/reset?user=alpha')
+        self.check('/ratelimit/reset?user=beta')
+
+        # All HTTP headers come through OK. First usage leaves us with 2 remaining
+        check('/ratelimit/a', None, 3, 2)
+        # /ratelimit/b uses the same pool as /a
+        check('/ratelimit/b', None, 3, 1)
+        # HTTP errors don't deduct from usage
+        check('/ratelimit/a?n=0', None, 3, 1, INTERNAL_SERVER_ERROR)
+        check('/ratelimit/b?n=0', None, 3, 1, INTERNAL_SERVER_ERROR)
+        # When usage exceeds, we get HTTP 429
+        check('/ratelimit/a', None, 3, 0)
+        check('/ratelimit/a', None, 3, 0, TOO_MANY_REQUESTS)
+        check('/ratelimit/b', None, 3, 0, TOO_MANY_REQUESTS)
+        # Different users get a different limits
+        check('/ratelimit/a', 'alpha', 3, 2)
+        check('/ratelimit/a', 'beta', 3, 2)
+        check('/ratelimit/b', 'alpha', 3, 1)
+        check('/ratelimit/b', 'beta', 3, 1)


### PR DESCRIPTION
Every handler supports rate-limiting via `ratelimit:`. For example:

```yaml
url:
  page:
    pattern: /api
    handler: FormHandler # or any handler
    kwargs:
      # ...
      ratelimit:
        keys: [daily, user.id]
        limit: 50
```

`keys` define how to rate-limit. It's an array of strings, or a comma-separated list of strings:

```yaml
# Set a weekly limit by user
        keys: [weekly, user]
        keys: weekly, user  # same as above
# Set a daily limit globally
        keys: [daily]
```

The strings can be:

- Time-based keys
  - `hourly`: Reset limit every hour (UTC)
  - `daily`: Reset limit every day (UTC)
  - `weekly`: Reset limit every week, starting Sunday (UTC)
  - `monthly`: Reset limit every month, starting 1st of the month (UTC)
  - `yearly`: Reset limit every month, starting 1-Jan (UTC)
- Any key from the [logging config](https://gramener.com/gramex/guide/config/#request-logging), e.g.
  - `user`: The unique ID of the user requesting the page (same as `user.id`)
  - `uri`: The full URL requested (after the host name)
  - `method`: The HTTP method requested. E.g. `GET` or `POST`
  - `ip`: The IP address of the client requesting the page
  - `args.<key>`: A specific argument. E.g. `args.x` returns the value of ?x=...
  - `headers.<key>`: A request HTTP header. E.g. `headers.User-Agent` is the browser’s user agent
  - `session.<key>`: A HTTP session key. E.g. `session.user` is the user object
  - `cookies.<key>`: Logs a specific cookie. E.g. `cookie.sid` is the session ID cookie
  - `env.<key>`: Logs an environment variable. E.g. `env.HOME` logs the user’s home directory

`keys` can also be defined with functions. For example:

```yaml
# Restrict by user's email domain name
        keys:
          - daily
          - function: handler.current_user.email.split('@')[-1]
# Refresh every 10 days. Divide seconds since epoch by 10 days. Round down
        keys:
          - user
          - function: int(pd.Timestamp.utcnow().timestamp() / 24 / 60 / 60 / 10)
```

`limit` is the maximum number of successful requests to the page. This can be a number or a function that returns a number. For example:

```yaml
# Set a constant limit of 50
        limit: 50
# Limit to 50 for logged-in users, 10 for others
        limit: {function: 50 if handler.current_user else 10}
```

On each request, Gramex computes the `keys` and `limit`, looks up usage for that key, and sets these HTTP headers:

- `X-RateLimit-Limit`: limit
- `X-RateLimit-Remaining`: limit minus usage
- `X-RateLimit-Reset`: seconds before window resets. Only available for `hourly`, `daily`, `weekly` and `monthly` keys
- `Retry-After`: same as `X-Ratelimit-Reset`, sent only if usage exceeds limit

If the usage exceeds the limit, Gramex raises a [HTTP 429 Too Many Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) response. This can be formatted via a custom error page.

If the response is successful, the usage increments by 1. If the response is a HTTP 5xx or HTTP 4xx, usage stays the same.

If a single API has multiple URLs (e.g. `/api1`, `/api2`, etc), add the same `ratelimit.pool:` to all. This combines their usage. For example:

```yaml
url:
  page1:
    pattern: /api1
    handler: FormHandler # or any handler
    kwargs:
      # ...
      ratelimit: &API_POOL
        pool: my-api-pool
        keys: [daily, user]
        limit: 50
  page2:
    pattern: /api2
    handler: FormHandler # or any handler
    kwargs:
      # ...
      ratelimit:
        <<: *API_POOL  # Copy config from earlier
```

Calling `/api1` and `api2` increase the SAME usage counter by 1.

To reset the API usage for any key, call `gramex.handlers.BaseHandler.ratelimit_reset(pool, keys)`. For example, this sets the usage of `x@example.com` on `2022-01-01` to zero.

```python
gramex.handlers.BaseHandler.ratelimit_reset('my-api-pool', ['2022-01-01', 'x@example.com'])
```
