### PR TITLE
FIX: FilterHandler in-memory works for all types of DBs

### DIFF
--- a/gramex/config.py
+++ b/gramex/config.py
@@ -96,7 +96,8 @@ def walk(node):
         RuntimeError: maximum recursion depth exceeded
     '''
     if hasattr(node, 'items'):
-        for key, value in node.items():
+        # Convert note.items() to list to prevent keys changing during iteration
+        for key, value in list(node.items()):
             yield from walk(value)
             yield key, value, node
     elif isinstance(node, list):

--- a/gramex/data.py
+++ b/gramex/data.py
@@ -1470,7 +1470,7 @@ def _filter_groupby_columns(by, cols, meta):
     '''
     colset = set(cols)
     for col in by:
-        if col in colset:
+        if col in colset and col not in meta['by']:
             meta['by'].append(col)
         else:
             meta['ignored'].append(('_by', col))

--- a/gramex/transforms/transforms.py
+++ b/gramex/transforms/transforms.py
@@ -541,7 +541,7 @@ def flattener(fields: dict, default: Any = None, filename: str = 'flatten'):
             body.append(f'\ttry: r[{field!r}] = {target}\n')
             body.append(f'\texcept (KeyError, TypeError, IndexError): r[{field!r}] = default\n')
         else:
-            body.append(f'\tr[{field}] = {target}\n')
+            body.append(f'\tr[{field!r}] = {target}\n')
 
     for field, source in fields.items():
         if not isinstance(field, str):

--- a/tests/test_filterhandler.py
+++ b/tests/test_filterhandler.py
@@ -13,7 +13,7 @@ def eqframe(result, expected, **kwargs):
 
 
 def unique_of(data: pd.DataFrame, cols):
-    return data.groupby(cols).size().reset_index().drop(0, 1)
+    return data.groupby(cols).size().reset_index().drop(0, axis=1)
 
 
 class TestFilterHandler(TestGramex):
@@ -106,6 +106,11 @@ class TestFilterHandler(TestGramex):
         result = self.get('/filters/sales', params=_args).json()
         expected = unique_of(self.sales, ['देश', 'city'])
         eqframe(result['देश,city'], expected)
+
+        _args = {'_c': ['city,city']}
+        result = self.get('/filters/sales', params=_args).json()
+        expected = unique_of(self.sales, ['city'])
+        eqframe(result['city,city'], expected)
 
         _args = {'_c': ['देश,city,product']}
         result = self.get('/filters/sales', params=_args).json()

--- a/tests/test_openapihandler.py
+++ b/tests/test_openapihandler.py
@@ -100,7 +100,7 @@ class TestOpenAPIHandler(TestGramex):
                 {
                     'in': 'query',
                     'description': '',
-                    'schema': {'type': ['string'], 'default': []},
+                    'schema': {'type': 'string', 'default': []},
                 },
                 params['l1'],
             )
@@ -108,7 +108,7 @@ class TestOpenAPIHandler(TestGramex):
                 {
                     'in': 'query',
                     'description': 'First value',
-                    'schema': {'type': ['integer'], 'default': 0},
+                    'schema': {'type': 'integer', 'default': 0},
                 },
                 params['i1'],
             )
@@ -116,7 +116,7 @@ class TestOpenAPIHandler(TestGramex):
                 {
                     'in': 'query',
                     'description': 'Second value',
-                    'schema': {'type': ['integer'], 'default': 0},
+                    'schema': {'type': 'integer', 'default': 0},
                 },
                 params['i2'],
             )
@@ -124,7 +124,7 @@ class TestOpenAPIHandler(TestGramex):
                 {
                     'in': 'query',
                     'description': '',
-                    'schema': {'type': ['string'], 'default': 'Total'},
+                    'schema': {'type': 'string', 'default': 'Total'},
                 },
                 params['s1'],
             )
@@ -132,7 +132,7 @@ class TestOpenAPIHandler(TestGramex):
                 {
                     'in': 'query',
                     'description': '',
-                    'schema': {'type': ['integer'], 'default': 0},
+                    'schema': {'type': 'integer', 'default': 0},
                 },
                 params['n1'],
             )
@@ -140,7 +140,7 @@ class TestOpenAPIHandler(TestGramex):
                 {
                     'in': 'query',
                     'description': '',
-                    'schema': {'type': ['string'], 'default': 0},
+                    'schema': {'type': 'string', 'default': 0},
                 },
                 params['n2'],
             )
@@ -148,7 +148,7 @@ class TestOpenAPIHandler(TestGramex):
                 {
                     'in': 'header',
                     'description': '',
-                    'schema': {'type': ['string'], 'default': ''},
+                    'schema': {'type': 'string', 'default': ''},
                 },
                 params['h'],
             )
@@ -156,7 +156,7 @@ class TestOpenAPIHandler(TestGramex):
                 {
                     'in': 'query',
                     'description': '',
-                    'schema': {'type': ['integer'], 'default': 200},
+                    'schema': {'type': 'integer', 'default': 200},
                 },
                 params['code'],
             )


### PR DESCRIPTION
Earlier, FilterHandler used in_memory= only for SQLAlchemy data stores. Now it works for all stores by running a `gramex.data.filter` on the superset of required data, and filtering the rest in memory.

Also, fixed a bug where duplicate column names raised an error. @umang1995 -- this should fix your issue.