### PR TITLE
BLD: Compute Gramex feature size & complexity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tests/watcher.txt
 *.csv
 *.xls*
 
+!reports/*.csv
 !tests/**/*.csv
 !tests/*.xlsx
 !testlib/**/*.csv

--- a/pkg/usage/gramexsize.py
+++ b/pkg/usage/gramexsize.py
@@ -81,7 +81,7 @@ def gramexsize(*dirs: str):
 
     result = pd.Series(total).reset_index()
     result.columns = ['codepath', 'yamlpath', 'complexity']
-    result.dropna(subset=['yamlpath']).to_csv(sys.stdout, index=False, lineterminator='\n')
+    result.dropna(subset=['yamlpath']).to_csv(sys.stdout, index=False)
 
 
 if __name__ == '__main__':

--- a/pkg/usage/gramexsize.py
+++ b/pkg/usage/gramexsize.py
@@ -1,0 +1,88 @@
+'''Saves cyclomatic complexity of Gramex code and corresponding YAML config.'''
+import ast
+import logging
+import mccabe
+import os
+import sys
+from collections import Counter
+from fnmatch import fnmatch
+from typing import Iterator
+
+folder = os.path.dirname(os.path.abspath(__file__))
+
+
+def complexity(dir: str) -> Iterator[dict]:
+    '''Yield cyclomatic complexity of each function in a folder.
+
+    Examples:
+        >>> for item in complexity('myproject/'):
+        ...     print(item['module'], item['entity'], item['complexity'])
+
+    Parameters:
+        dir: path to folder to locate .py files in
+
+    It returns an iterator of dictionaries with keys:
+
+    - `source`: Path to `.py` file relative to `dir`, e.g. `pkg/module.py`
+    - `module`: `path` converted to module name, `e.g. `pkg.module`
+    - `entity`: function or method, e.g. `ClassName.method_name`. For code outside functions,
+        this is `If`, `TryExcept`, `With`, `Loop`, or "Stmt".
+    - `lineno`: line at which `entity` appears in `source`
+    - `column`: column at which `entity` appears in `source`
+    - `complexity`: McCabe (cyclomatic) complexity of the `entity`
+    '''
+    for root, _dirs, files in os.walk(dir):
+        for file in files:
+            if file.lower().endswith('.py'):
+                path: str = os.path.join(root, file)
+                rel_path: str = os.path.relpath(path, dir)
+                with open(path, 'rb') as handle:
+                    code = handle.read()
+                tree = compile(code, rel_path, 'exec', ast.PyCF_ONLY_AST)
+                visitor = mccabe.PathGraphingAstVisitor()
+                visitor.preorder(tree, visitor)
+                for node in visitor.graphs.values():
+                    yield {
+                        'source': rel_path,
+                        'module': rel_path[:-3].replace(os.sep, '.'),
+                        'entity': node.entity,
+                        'lineno': node.lineno,
+                        'column': node.column,
+                        'complexity': node.complexity(),
+                    }
+
+
+def gramexsize(*dirs: str):
+    '''Saves complexity of Gramex code and corresponding YAML config in target.
+
+    Examples:
+
+        >>> gramexsize('/path/to/gramex/', '/path/to/gramexenterprise/', target='codesize.csv')
+    '''
+    import yaml
+    import pandas as pd
+
+    conf_file = os.path.join(folder, 'gramexsize.yaml')
+    with open(conf_file) as handle:
+        conf = yaml.safe_load(handle)
+
+    total = Counter()
+    for dir in dirs:
+        for node in complexity(os.path.abspath(dir)):
+            key = f"{node['module']}.{node['entity']}"
+            for codepath, yamlpaths in conf['code2yaml'].items():
+                if fnmatch(key, codepath):
+                    yamlpaths = yamlpaths if isinstance(yamlpaths, list) else [yamlpaths]
+                    for yamlpath in yamlpaths:
+                        total[codepath, yamlpath] += node['complexity']
+                    break
+            else:
+                logging.warning(f'Unmatched {key}')
+
+    result = pd.Series(total).reset_index()
+    result.columns = ['codepath', 'yamlpath', 'complexity']
+    result.dropna(subset=['yamlpath']).to_csv(sys.stdout, index=False, lineterminator='\n')
+
+
+if __name__ == '__main__':
+    gramexsize(*sys.argv[1:])

--- a/pkg/usage/gramexsize.yaml
+++ b/pkg/usage/gramexsize.yaml
@@ -1,0 +1,223 @@
+# Maps Python code to Gramex features
+yaml2feature: true
+
+# Map code to gramex.yaml paths that use it
+# DO NOT SORT BLINDLY! Order matters. ".*" must be as far down as possible
+code2yaml:
+  gramex.cache._delete_temp_files: "*"
+  gramex.cache.open: "*"
+  gramex.cache.stat: "*"
+  gramex.cache.save: url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler
+  gramex.cache.query: url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler
+  gramex.cache.reload_module: "*"
+  gramex.cache.urlfetch: alert
+  gramex.cache.Subprocess.*: url.*.handler=ProcessHandler|Process
+  gramex.cache.daemon: [url.*.handler=ComicHandler|Comic, import.*.path=$GRAMEXAPPS/languagetool/gramex.yaml]
+  gramex.cache.get_store: [app.session, url.*.kwargs.store]
+  gramex.cache.KeyStore.*: [app.session.type=memory, url.*.kwargs.store.type=memory]
+  gramex.cache.RedisStore.*: [app.session.type=redis, url.*.kwargs.store.type=redis]
+  gramex.cache.SQLiteStore.*: [app.session.type=sqlite, url.*.kwargs.store.type=sqlite]
+  gramex.cache.HDF5Store.*: [app.session.type=hdf5, url.*.kwargs.store.type=hdf5]
+  gramex.cache.JSONStore.*: [app.session.type=json, url.*.kwargs.store.type=json]
+  # TODO: gramex.cache.* may be too broad?
+  gramex.cache.*: cache
+  gramex.config.*: "*"
+  # TODO: gramex.data.* may be too broad?
+  gramex.data.*: url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler
+  gramex.debug.*: TODO - if any PY code uses gramex.debug
+  gramex.install.*: TODO - Gramex app installation & management
+  gramex.license.*: TODO - Gramex enterprise license management
+  gramex.ml.Classifier.*: url.*.handler=ModelHandler
+  gramex.ml._conda_r_home: TODO - if any PY code uses gramex.ml.r
+  gramex.ml.r: TODO - if any PY code uses gramex.ml.r
+  gramex.ml.groupmeans: TODO - if any PY code use gramex.ml.groupmeans
+  gramex.ml.weighted_avg: TODO - if any PY code use gramex.ml.groupmeans
+  gramex.ml._google_translate: url.*.kwargs.function=gramex.ml.translater
+  gramex.ml.translate: url.*.kwargs.function=gramex.ml.translater
+  gramex.ml.translater: url.*.kwargs.function=gramex.ml.translater
+  gramex.ml.languagetool: import.*.path=$GRAMEXAPPS/languagetool/gramex.yaml
+  gramex.ml.languagetoolrequest: import.*.path=$GRAMEXAPPS/languagetool/gramex.yaml
+  gramex.ml.languagetool_download: import.*.path=$GRAMEXAPPS/languagetool/gramex.yaml
+  gramex.ml.*: TODO - if any PY code uses topcause
+  gramex.ml_api.*: url.*.handler=MLHandler|ML
+  gramex.pynode.*: url.*.handler=ComicHandler|Comic
+  gramex.scale.*: TODO - if any PY code uses gramex.scale
+  gramex.secrets.commandline: TODO - if deployment uses secrets
+  gramex.sm_api.*: url.*.handler=MLHandler|ML
+  gramex.topcause.*: TODO - if any PY code uses topcause
+  gramex.transformers.*: url.*.handler=MLHandler|ML
+  gramex.winservice.*: TODO - if app is deployed on Windows server
+  gramex.__init__.*: "*"
+  gramex.apps.admin.*: import.*.path=$GRAMEXAPPS/admin/gramex.yaml
+  gramex.apps.admin2.*: import.*.path=$GRAMEXAPPS/admin2/gramex.yaml
+  gramex.apps.filemanager.*: import.*.path=$GRAMEXAPPS/filemanager/gramex.yaml
+  gramex.apps.logviewer.*: import.*.path=$GRAMEXAPPS/logviewer/gramex.yaml
+  gramex.apps.mail.*: import.*.path=$GRAMEXAPPS/mail/gramex.yaml
+  gramex.apps.ui.*: import.*.path=$GRAMEXAPPS/ui/gramex.yaml
+  gramex.apps.uifactory.*: import.*.path=$GRAMEXAPPS/uifactory/gramex.yaml
+  gramex.apps.update.*: import.*.path=$GRAMEXAPPS/update/gramex.yaml
+  gramex.handlers.authhandler.AuthHandler.*: url.*.handler=GoogleAuth|SimpleAuth|OAuth2|FacebookAuth|TwitterAuth|SAMLAuth|SAMLAuth2|LDAPAuth|DBAuth|IntegratedAuth|SMSAuth|EmailAuth
+  gramex.handlers.authhandler.LogoutHandler.*: url.*.handler=LogoutHandler
+  gramex.handlers.authhandler.GoogleAuth.*: url.*.handler=GoogleAuth
+  gramex.handlers.authhandler.SimpleAuth.*: url.*.handler=SimpleAuth
+  # TODO: Also check Python code that uses handler.*()
+  gramex.handlers.basehandler.BaseHandler.argparse: url.*.handler=CaptureHandler|MLHandler|ModelHandler|OpenAPIHandler
+  gramex.handlers.basehandler.BaseHandler.authorize: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseHandler.create_template_loader: url.*.kwargs.template
+  gramex.handlers.basehandler.BaseHandler.get_arg: url
+  gramex.handlers.basehandler.BaseHandler.get_current_user: url
+  gramex.handlers.basehandler.BaseHandler.initialize: url
+  gramex.handlers.basehandler.BaseHandler.log_exception: url
+  gramex.handlers.basehandler.BaseHandler.on_finish: url
+  gramex.handlers.basehandler.BaseHandler.prepare: url
+  gramex.handlers.basehandler.BaseHandler.set_default_headers: url
+  gramex.handlers.basehandler.BaseMixin._cached_get: url
+  gramex.handlers.basehandler.BaseMixin._cors_options: url.*.kwargs.cors
+  gramex.handlers.basehandler.BaseMixin._error_fn: url.*.kwargs.error
+  gramex.handlers.basehandler.BaseMixin._get_store: url.*.kwargs.cache
+  gramex.handlers.basehandler.BaseMixin._purge_keys: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin._set_new_session_id: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin._write_custom_error: url.*.kwargs.error
+  gramex.handlers.basehandler.BaseMixin._write_headers: url.*.kwargs.headers
+  gramex.handlers.basehandler.BaseMixin.apikey: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.authorize: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.check_cors: url.*.kwargs.kwargs
+  gramex.handlers.basehandler.BaseMixin.check_http_method: url.*.kwargs.methods
+  gramex.handlers.basehandler.BaseMixin.check_ratelimit: url.*.kwargs.ratelimit
+  gramex.handlers.basehandler.BaseMixin.clear_special_keys: url
+  gramex.handlers.basehandler.BaseMixin.cors_origin: url.*.kwargs.cors
+  gramex.handlers.basehandler.BaseMixin.debug_exception: url
+  gramex.handlers.basehandler.BaseMixin.get_list: url
+  gramex.handlers.basehandler.BaseMixin.get_otp: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.get_session: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.noop: url
+  gramex.handlers.basehandler.BaseMixin.otp: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.override_user: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.redirect_next: url.*.kwargs.redirect
+  gramex.handlers.basehandler.BaseMixin.reset_ratelimit: url.*.kwargs.ratelimit
+  gramex.handlers.basehandler.BaseMixin.revoke_apikey: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.revoke_otp: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.save_redirect_page: url.*.kwargs.redirect
+  gramex.handlers.basehandler.BaseMixin.save_session: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.session: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.set_last_visited: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.set_ratelimit_headers: url.*.kwargs.ratelimit
+  gramex.handlers.basehandler.BaseMixin.setup: url
+  gramex.handlers.basehandler.BaseMixin.setup_auth: url.*.kwargs.auth
+  gramex.handlers.basehandler.BaseMixin.setup_cors: url.*.kwargs.cors
+  gramex.handlers.basehandler.BaseMixin.setup_default_kwargs: url
+  gramex.handlers.basehandler.BaseMixin.setup_error: url.*.kwargs.error
+  gramex.handlers.basehandler.BaseMixin.setup_httpmethods: url.*.kwargs.methods
+  gramex.handlers.basehandler.BaseMixin.setup_log: url.*.kwargs.log
+  gramex.handlers.basehandler.BaseMixin.setup_ratelimit: url.*.kwargs.ratelimit
+  gramex.handlers.basehandler.BaseMixin.setup_redirect: url.*.kwargs.redirect
+  gramex.handlers.basehandler.BaseMixin.setup_session: url.*.kwargs.session
+  gramex.handlers.basehandler.BaseMixin.setup_transform: url.*.kwargs.session
+  gramex.handlers.basehandler.BaseMixin.setup_xsrf: url.*.kwargs.xsrf
+  gramex.handlers.basehandler.BaseMixin.update_ratelimit: url.*.kwargs.ratelimit
+  gramex.handlers.basehandler.BaseMixin.xsrf_ajax: url
+  gramex.handlers.basehandler.BaseMixin.xsrf_check_required: url
+  gramex.handlers.basehandler.BaseWebSocketHandler.*: url.*.handler=WebSocketHandler|Websocket
+  gramex.handlers.basehandler.SetupFailedHandler.get: url
+  gramex.handlers.basehandler._check_condition: url.*.kwargs.auth.membership
+  gramex.handlers.basehandler.check_membership: url.*.kwargs.auth.membership
+  gramex.handlers.capturehandler.*: url.*.handler=CaptureHandler|Screenshot
+  gramex.handlers.comichandler.*: url.*.handler=ComicHandler|Comic
+  gramex.handlers.drivehandler.*: url.*.handler=DriveHandler|Storage
+  gramex.handlers.filehandler.*: url.*.handler=FileHandler|DirectoryHandler|File
+  gramex.handlers.formhandler.*: url.*.handler=FormHandler|Data
+  gramex.handlers.functionhandler.*: url.*.handler=FunctionHandler|Function
+  gramex.handlers.jsonhandler.*: url.*.handler=JSONHandler|JSON
+  gramex.handlers.mlhandler.get_model: url.*.handler=MLHandler|ML
+  gramex.handlers.mlhandler.MLHandler.*: url.*.handler=MLHandler|ML
+  gramex.handlers.mlhandler.MLPredictor.*: url.*.handler=MLPredictor
+  gramex.handlers.modelhandler.*: url.*.handler=ModelHandler
+  gramex.handlers.openapihandler.*: url.*.handler=OpenAPIHandler|OpenAPI
+  gramex.handlers.pptxhandler.*: url.*.handler=PPTXHandler, Slide
+  gramex.handlers.processhandler.*: url.*.handler=ProcessHandler|Process
+  gramex.handlers.proxyhandler.*: url.*.handler=ProxyHandler|Proxy
+  gramex.handlers.socialhandler.SocialHandler.*: url.*.handler=TwitterRESTHandler|Twitter|FacebookGraphHandler|Facebook
+  gramex.handlers.socialhandler.TwitterRESTHandler.*: url.*.handler=TwitterRESTHandler|Twitter
+  gramex.handlers.socialhandler.FacebookGraphHandler.*: url.*.handler=FacebookGraphHandler|Facebook
+  gramex.handlers.uploadhandler.*: url.*.handler=UploadHandler|Upload
+  gramex.handlers.websockethandler.*: url.*.handler=WebSocketHandler|Websocket
+  # gramex.handlers.__init__.* has a conditional import of GramexEnterprise
+  gramex.handlers.__init__.*: url.*.handler=OAuth2|FacebookAuth|TwitterAuth|SAMLAuth|SAMLAuth2|LDAPAuth|DBAuth|IntegratedAuth|SMSAuth|EmailAuth
+  gramex.pptgen.*: url.*.handler=PPTXHandler
+  gramex.pptgen2.*: url.*.handler=PPTXHandler
+  gramex.services.emailer.*: email
+  gramex.services.rediscache.*: cache.*.type=redis
+  gramex.services.scheduler.*: schedule
+  gramex.services.sms.*: sms
+  gramex.services.ttlcache.*: cache.*.type=memory
+  gramex.services.urlcache.get_cachefile: cache
+  gramex.services.urlcache.CacheFile.*: cache
+  gramex.services.urlcache.MemoryCacheFile.*: [cache.*.type=memory, cache.*.type=disk]
+  gramex.services.urlcache.RedisCacheFile.*: cache.*.type=redis
+  gramex.services.watcher.*: watch
+  gramex.services.__init__.version: version
+  gramex.services.__init__.log: log
+  gramex.services.__init__.app: app
+  gramex.services.__init__.schedule: schedule
+  gramex.services.__init__.alert: alert
+  gramex.services.__init__.threadpool: threadpool
+  gramex.services.__init__.url: url
+  gramex.services.__init__.mime: mime
+  gramex.services.__init__.watch: watch
+  gramex.services.__init__.cache: cache
+  gramex.services.__init__.eventlog: eventlog
+  gramex.services.__init__.email: email
+  gramex.services.__init__.sms: sms
+  gramex.services.__init__.handlers: handlers
+  gramex.services.__init__.encrypt: encrypt
+  gramex.services.__init__.test: test
+  gramex.services.__init__.gramexlog: gramexlog
+  gramex.services.__init__.storelocations: storelocations
+  gramex.services.__init__._storelocations_purge: storelocations
+  gramex.services.__init__.GramexApp.log_request: log
+  gramex.services.__init__.GramexApp.clear_handlers: app
+  gramex.services.__init__.create_alert: alert
+  gramex.services.__init__._markdown_convert: alert
+  gramex.services.__init__._tmpl: alert
+  gramex.services.__init__._stop_all_tasks: [schedule, alert]
+  gramex.services.__init__._sort_url_patterns: url.*.pattern
+  gramex.services.__init__._url_normalize: url.*.pattern
+  gramex.services.__init__._get_cache_key: url.*.cache
+  gramex.services.__init__._cache_generator: url.*.cache
+  gramex.transforms.auth.ensure_single_session: url.*.handlers.kwargs.action.function:ensure_single_session
+  gramex.transforms.template.template: url.*.kwargs.template
+  gramex.transforms.template.scss: url.*.kwargs.scss
+  gramex.transforms.template.ts: url.*.kwargs.ts
+  gramex.transforms.template.vue: url.*.kwargs.vue
+  gramex.transforms.template.CacheLoader.*: url.*.kwargs.template
+  gramex.transforms.transforms.identity: TODO - if any PY code uses @handler
+  gramex.transforms.transforms._arg_repr: TODO - same as build_transform (maybe always)
+  gramex.transforms.transforms._full_name: TODO - same as build_transform (maybe always)
+  gramex.transforms.transforms.module_names: TODO - same as build_transform (maybe always)
+  gramex.transforms.transforms.build_transform: TODO - same as build_transform (maybe always)
+  gramex.transforms.transforms.build_pipeline: TODO - same as build_transform (maybe always)
+  gramex.transforms.transforms.condition: DEPRECATED
+  gramex.transforms.transforms.flattener: TODO - if any PY code use flatter()
+  gramex.transforms.transforms.once: TODO - if any PY code uses once()
+  gramex.transforms.transforms.typelist: TODO - if any PY code uses @handler
+  gramex.transforms.transforms.convert: TODO - if any PY code uses @handler
+  gramex.transforms.transforms.handler: TODO - if any PY code uses @handler
+  gramex.transforms.transforms.handler_expr: [log.handlers.user.keys, log.handlers.requests.keys, gramexlog]
+  gramex.transforms.transforms.build_log_info: [log.handlers.user.keys, log.handlers.requests.keys, gramexlog]
+  gramex.transforms.twitterstream.*: TODO - if any PY code uses TwitterStream
+  gramexenterprise.handlers.authhandler.OAuth2.*: url.*.handler=OAuth2
+  gramexenterprise.handlers.authhandler.FacebookAuth.*: url.*.handler=FacebookAuth
+  gramexenterprise.handlers.authhandler.TwitterAuth.*: url.*.handler=TwitterAuth
+  gramexenterprise.handlers.authhandler.SAMLAuth.*: url.*.handler=SAMLAuth
+  gramexenterprise.handlers.authhandler.SAMLAuth2.*: url.*.handler=SAMLAuth2
+  gramexenterprise.handlers.authhandler.LDAPAuth.*: url.*.handler=LDAPAuth
+  gramexenterprise.handlers.authhandler.DBAuth.*: url.*.handler=DBAuth
+  gramexenterprise.handlers.authhandler.IntegratedAuth.*: url.*.handler=IntegratedAuth
+  gramexenterprise.handlers.authhandler.SMSAuth.*: url.*.handler=SMSAuth
+  gramexenterprise.handlers.authhandler.EmailAuth.*: url.*.handler=EmailAuth
+  # These Gramex features shouldn't count towards project complexity/effort
+  build.*: null
+  pkg.*: null
+  pytest.*: null
+  testlib.*: null
+  tests.*: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ test = [
     "datasets",  # for gramex.transformers
     "elasticsearch7",  # for gramexlog: features
     "gramexenterprise",  # for auth testing
+    "mccabe",  # for pkg/usage/pycomplexity.py
     "nose",  # for all test cases
     "pdfminer.six",  # for test_capturehandler
     "psycopg2 >= 2.7.1",  # for PostgreSQL tests

--- a/reports/gramexsize.csv
+++ b/reports/gramexsize.csv
@@ -1,0 +1,221 @@
+codepath,yamlpath,complexity
+gramex.cache._delete_temp_files,*,3
+gramex.cache.open,*,13
+gramex.cache.stat,*,2
+gramex.cache.save,url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler,4
+gramex.cache.query,url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler,9
+gramex.cache.reload_module,*,5
+gramex.cache.urlfetch,alert,6
+gramex.cache.Subprocess.*,url.*.handler=ProcessHandler|Process,25
+gramex.cache.daemon,url.*.handler=ComicHandler|Comic,24
+gramex.cache.daemon,import.*.path=$GRAMEXAPPS/languagetool/gramex.yaml,24
+gramex.cache.get_store,app.session,6
+gramex.cache.get_store,url.*.kwargs.store,6
+gramex.cache.KeyStore.*,app.session.type=memory,14
+gramex.cache.KeyStore.*,url.*.kwargs.store.type=memory,14
+gramex.cache.RedisStore.*,app.session.type=redis,10
+gramex.cache.RedisStore.*,url.*.kwargs.store.type=redis,10
+gramex.cache.SQLiteStore.*,app.session.type=sqlite,5
+gramex.cache.SQLiteStore.*,url.*.kwargs.store.type=sqlite,5
+gramex.cache.HDF5Store.*,app.session.type=hdf5,18
+gramex.cache.HDF5Store.*,url.*.kwargs.store.type=hdf5,18
+gramex.cache.JSONStore.*,app.session.type=json,15
+gramex.cache.JSONStore.*,url.*.kwargs.store.type=json,15
+gramex.cache.*,cache,49
+gramex.config.*,*,158
+gramex.data.*,url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler,320
+gramex.debug.*,TODO - if any PY code uses gramex.debug,32
+gramex.install.*,TODO - Gramex app installation & management,128
+gramex.license.*,TODO - Gramex enterprise license management,9
+gramex.ml.Classifier.*,url.*.handler=ModelHandler,15
+gramex.ml._conda_r_home,TODO - if any PY code uses gramex.ml.r,4
+gramex.ml.r,TODO - if any PY code uses gramex.ml.r,11
+gramex.ml.groupmeans,TODO - if any PY code use gramex.ml.groupmeans,11
+gramex.ml.weighted_avg,TODO - if any PY code use gramex.ml.groupmeans,1
+gramex.ml._google_translate,url.*.kwargs.function=gramex.ml.translater,5
+gramex.ml.translate,url.*.kwargs.function=gramex.ml.translater,10
+gramex.ml.translater,url.*.kwargs.function=gramex.ml.translater,1
+gramex.ml.languagetool,import.*.path=$GRAMEXAPPS/languagetool/gramex.yaml,5
+gramex.ml.languagetoolrequest,import.*.path=$GRAMEXAPPS/languagetool/gramex.yaml,7
+gramex.ml.languagetool_download,import.*.path=$GRAMEXAPPS/languagetool/gramex.yaml,3
+gramex.ml.*,TODO - if any PY code uses topcause,3
+gramex.ml_api.*,url.*.handler=MLHandler|ML,55
+gramex.pynode.*,url.*.handler=ComicHandler|Comic,17
+gramex.scale.*,TODO - if any PY code uses gramex.scale,13
+gramex.secrets.commandline,TODO - if deployment uses secrets,6
+gramex.sm_api.*,url.*.handler=MLHandler|ML,20
+gramex.topcause.*,TODO - if any PY code uses topcause,15
+gramex.transformers.*,url.*.handler=MLHandler|ML,31
+gramex.winservice.*,TODO - if app is deployed on Windows server,22
+gramex.__init__.*,*,49
+gramex.apps.admin.*,import.*.path=$GRAMEXAPPS/admin/gramex.yaml,28
+gramex.apps.admin2.*,import.*.path=$GRAMEXAPPS/admin2/gramex.yaml,53
+gramex.apps.filemanager.*,import.*.path=$GRAMEXAPPS/filemanager/gramex.yaml,7
+gramex.apps.logviewer.*,import.*.path=$GRAMEXAPPS/logviewer/gramex.yaml,59
+gramex.apps.mail.*,import.*.path=$GRAMEXAPPS/mail/gramex.yaml,2
+gramex.apps.ui.*,import.*.path=$GRAMEXAPPS/ui/gramex.yaml,28
+gramex.apps.uifactory.*,import.*.path=$GRAMEXAPPS/uifactory/gramex.yaml,21
+gramex.apps.update.*,import.*.path=$GRAMEXAPPS/update/gramex.yaml,14
+gramex.handlers.authhandler.AuthHandler.*,url.*.handler=GoogleAuth|SimpleAuth|OAuth2|FacebookAuth|TwitterAuth|SAMLAuth|SAMLAuth2|LDAPAuth|DBAuth|IntegratedAuth|SMSAuth|EmailAuth,33
+gramex.handlers.authhandler.LogoutHandler.*,url.*.handler=LogoutHandler,4
+gramex.handlers.authhandler.GoogleAuth.*,url.*.handler=GoogleAuth,5
+gramex.handlers.authhandler.SimpleAuth.*,url.*.handler=SimpleAuth,5
+gramex.handlers.basehandler.BaseMixin.setup,url,2
+gramex.handlers.basehandler.BaseMixin.clear_special_keys,url,3
+gramex.handlers.basehandler.BaseMixin.get_list,url,5
+gramex.handlers.basehandler.BaseMixin.setup_httpmethods,url.*.kwargs.methods,2
+gramex.handlers.basehandler.BaseMixin.check_http_method,url.*.kwargs.methods,2
+gramex.handlers.basehandler.BaseMixin.setup_cors,url.*.kwargs.cors,5
+gramex.handlers.basehandler.BaseMixin.check_cors,url.*.kwargs.kwargs,3
+gramex.handlers.basehandler.BaseMixin.cors_origin,url.*.kwargs.cors,5
+gramex.handlers.basehandler.BaseMixin._cors_options,url.*.kwargs.cors,9
+gramex.handlers.basehandler.BaseMixin.setup_default_kwargs,url,1
+gramex.handlers.basehandler.BaseMixin.setup_transform,url.*.kwargs.session,2
+gramex.handlers.basehandler.BaseMixin._purge_keys,url.*.kwargs.auth,7
+gramex.handlers.basehandler.BaseMixin._get_store,url.*.kwargs.cache,2
+gramex.handlers.basehandler.BaseMixin.setup_session,url.*.kwargs.session,3
+gramex.handlers.basehandler.BaseMixin.setup_ratelimit,url.*.kwargs.ratelimit,18
+gramex.handlers.basehandler.BaseMixin.reset_ratelimit,url.*.kwargs.ratelimit,2
+gramex.handlers.basehandler.BaseMixin.setup_redirect,url.*.kwargs.redirect,13
+gramex.handlers.basehandler.BaseMixin.setup_auth,url.*.kwargs.auth,8
+gramex.handlers.basehandler.BaseMixin.authorize,url.*.kwargs.auth,1
+gramex.handlers.basehandler.BaseMixin.setup_log,url.*.kwargs.log,1
+gramex.handlers.basehandler.BaseMixin._error_fn,url.*.kwargs.error,5
+gramex.handlers.basehandler.BaseMixin.setup_error,url.*.kwargs.error,13
+gramex.handlers.basehandler.BaseMixin.setup_xsrf,url.*.kwargs.xsrf,1
+gramex.handlers.basehandler.BaseMixin.xsrf_check_required,url,1
+gramex.handlers.basehandler.BaseMixin.xsrf_ajax,url,2
+gramex.handlers.basehandler.BaseMixin.noop,url,1
+gramex.handlers.basehandler.BaseMixin.save_redirect_page,url.*.kwargs.redirect,3
+gramex.handlers.basehandler.BaseMixin.redirect_next,url.*.kwargs.redirect,2
+gramex.handlers.basehandler.BaseMixin._cached_get,url,2
+gramex.handlers.basehandler.BaseMixin._write_headers,url.*.kwargs.headers,4
+gramex.handlers.basehandler.BaseMixin.debug_exception,url,3
+gramex.handlers.basehandler.BaseMixin._write_custom_error,url.*.kwargs.error,7
+gramex.handlers.basehandler.BaseMixin.session,url.*.kwargs.auth,1
+gramex.handlers.basehandler.BaseMixin._set_new_session_id,url.*.kwargs.auth,4
+gramex.handlers.basehandler.BaseMixin.get_session,url.*.kwargs.auth,6
+gramex.handlers.basehandler.BaseMixin.save_session,url.*.kwargs.auth,2
+gramex.handlers.basehandler.BaseMixin.otp,url.*.kwargs.auth,2
+gramex.handlers.basehandler.BaseMixin.get_otp,url.*.kwargs.auth,4
+gramex.handlers.basehandler.BaseMixin.revoke_otp,url.*.kwargs.auth,1
+gramex.handlers.basehandler.BaseMixin.apikey,url.*.kwargs.auth,1
+gramex.handlers.basehandler.BaseMixin.revoke_apikey,url.*.kwargs.auth,1
+gramex.handlers.basehandler.BaseMixin.override_user,url.*.kwargs.auth,7
+gramex.handlers.basehandler.BaseMixin.set_last_visited,url.*.kwargs.auth,3
+gramex.handlers.basehandler.BaseMixin.check_ratelimit,url.*.kwargs.ratelimit,2
+gramex.handlers.basehandler.BaseMixin.update_ratelimit,url.*.kwargs.ratelimit,2
+gramex.handlers.basehandler.BaseMixin.set_ratelimit_headers,url.*.kwargs.ratelimit,2
+gramex.handlers.basehandler.BaseHandler.initialize,url,8
+gramex.handlers.basehandler.BaseHandler.get_arg,url,3
+gramex.handlers.basehandler.BaseHandler.prepare,url,2
+gramex.handlers.basehandler.BaseHandler.set_default_headers,url,1
+gramex.handlers.basehandler.BaseHandler.on_finish,url,2
+gramex.handlers.basehandler.BaseHandler.get_current_user,url,1
+gramex.handlers.basehandler.BaseHandler.log_exception,url,1
+gramex.handlers.basehandler.BaseHandler.authorize,url.*.kwargs.auth,10
+gramex.handlers.basehandler.BaseHandler.argparse,url.*.handler=CaptureHandler|MLHandler|ModelHandler|OpenAPIHandler,26
+gramex.handlers.basehandler.BaseHandler.create_template_loader,url.*.kwargs.template,1
+gramex.handlers.basehandler.BaseWebSocketHandler.*,url.*.handler=WebSocketHandler|Websocket,13
+gramex.handlers.basehandler.SetupFailedHandler.get,url,1
+gramex.handlers.basehandler.check_membership,url.*.kwargs.auth.membership,4
+gramex.handlers.basehandler._check_condition,url.*.kwargs.auth.membership,6
+gramex.handlers.capturehandler.*,url.*.handler=CaptureHandler|Screenshot,46
+gramex.handlers.comichandler.*,url.*.handler=ComicHandler|Comic,6
+gramex.handlers.drivehandler.*,url.*.handler=DriveHandler|Storage,36
+gramex.handlers.filehandler.*,url.*.handler=FileHandler|DirectoryHandler|File,59
+gramex.handlers.formhandler.*,url.*.handler=FormHandler|Data,62
+gramex.handlers.functionhandler.*,url.*.handler=FunctionHandler|Function,14
+gramex.handlers.jsonhandler.*,url.*.handler=JSONHandler|JSON,31
+gramex.handlers.mlhandler.get_model,url.*.handler=MLHandler|ML,6
+gramex.handlers.mlhandler.MLHandler.*,url.*.handler=MLHandler|ML,74
+gramex.handlers.mlhandler.MLPredictor.*,url.*.handler=MLPredictor,6
+gramex.handlers.modelhandler.*,url.*.handler=ModelHandler,33
+gramex.handlers.openapihandler.*,url.*.handler=OpenAPIHandler|OpenAPI,21
+gramex.handlers.pptxhandler.*,"url.*.handler=PPTXHandler, Slide",3
+gramex.handlers.processhandler.*,url.*.handler=ProcessHandler|Process,17
+gramex.handlers.proxyhandler.*,url.*.handler=ProxyHandler|Proxy,23
+gramex.handlers.socialhandler.SocialHandler.*,url.*.handler=TwitterRESTHandler|Twitter|FacebookGraphHandler|Facebook,23
+gramex.handlers.socialhandler.TwitterRESTHandler.*,url.*.handler=TwitterRESTHandler|Twitter,8
+gramex.handlers.socialhandler.FacebookGraphHandler.*,url.*.handler=FacebookGraphHandler|Facebook,6
+gramex.handlers.uploadhandler.*,url.*.handler=UploadHandler|Upload,44
+gramex.handlers.websockethandler.*,url.*.handler=WebSocketHandler|Websocket,7
+gramex.handlers.__init__.*,url.*.handler=OAuth2|FacebookAuth|TwitterAuth|SAMLAuth|SAMLAuth2|LDAPAuth|DBAuth|IntegratedAuth|SMSAuth|EmailAuth,4
+gramex.pptgen.*,url.*.handler=PPTXHandler,363
+gramex.pptgen2.*,url.*.handler=PPTXHandler,244
+gramex.services.emailer.*,email,31
+gramex.services.rediscache.*,cache.*.type=redis,23
+gramex.services.scheduler.*,schedule,26
+gramex.services.sms.*,sms,10
+gramex.services.ttlcache.*,cache.*.type=memory,46
+gramex.services.urlcache.get_cachefile,cache,4
+gramex.services.urlcache.CacheFile.*,cache,3
+gramex.services.urlcache.MemoryCacheFile.*,cache.*.type=memory,4
+gramex.services.urlcache.MemoryCacheFile.*,cache.*.type=disk,4
+gramex.services.urlcache.RedisCacheFile.*,cache.*.type=redis,4
+gramex.services.watcher.*,watch,23
+gramex.services.__init__.version,version,2
+gramex.services.__init__.log,log,10
+gramex.services.__init__.app,app,23
+gramex.services.__init__.schedule,schedule,5
+gramex.services.__init__.alert,alert,7
+gramex.services.__init__.threadpool,threadpool,2
+gramex.services.__init__.url,url,15
+gramex.services.__init__.mime,mime,2
+gramex.services.__init__.watch,watch,9
+gramex.services.__init__.cache,cache,10
+gramex.services.__init__.eventlog,eventlog,6
+gramex.services.__init__.email,email,3
+gramex.services.__init__.sms,sms,6
+gramex.services.__init__.handlers,handlers,1
+gramex.services.__init__.encrypt,encrypt,1
+gramex.services.__init__.test,test,1
+gramex.services.__init__.gramexlog,gramexlog,11
+gramex.services.__init__.storelocations,storelocations,2
+gramex.services.__init__._storelocations_purge,storelocations,1
+gramex.services.__init__.GramexApp.log_request,log,4
+gramex.services.__init__.GramexApp.clear_handlers,app,1
+gramex.services.__init__.create_alert,alert,52
+gramex.services.__init__._markdown_convert,alert,2
+gramex.services.__init__._tmpl,alert,2
+gramex.services.__init__._stop_all_tasks,schedule,2
+gramex.services.__init__._stop_all_tasks,alert,2
+gramex.services.__init__._sort_url_patterns,url.*.pattern,1
+gramex.services.__init__._url_normalize,url.*.pattern,2
+gramex.services.__init__._get_cache_key,url.*.cache,10
+gramex.services.__init__._cache_generator,url.*.cache,5
+gramex.transforms.auth.ensure_single_session,url.*.handlers.kwargs.action.function:ensure_single_session,7
+gramex.transforms.template.template,url.*.kwargs.template,4
+gramex.transforms.template.scss,url.*.kwargs.scss,1
+gramex.transforms.template.ts,url.*.kwargs.ts,1
+gramex.transforms.template.vue,url.*.kwargs.vue,1
+gramex.transforms.template.CacheLoader.*,url.*.kwargs.template,3
+gramex.transforms.transforms.identity,TODO - if any PY code uses @handler,1
+gramex.transforms.transforms._arg_repr,TODO - same as build_transform (maybe always),4
+gramex.transforms.transforms._full_name,TODO - same as build_transform (maybe always),3
+gramex.transforms.transforms.module_names,TODO - same as build_transform (maybe always),11
+gramex.transforms.transforms.build_transform,TODO - same as build_transform (maybe always),15
+gramex.transforms.transforms.build_pipeline,TODO - same as build_transform (maybe always),15
+gramex.transforms.transforms.condition,DEPRECATED,8
+gramex.transforms.transforms.flattener,TODO - if any PY code use flatter(),10
+gramex.transforms.transforms.once,TODO - if any PY code uses once(),5
+gramex.transforms.transforms.typelist,TODO - if any PY code uses @handler,2
+gramex.transforms.transforms.convert,TODO - if any PY code uses @handler,2
+gramex.transforms.transforms.handler,TODO - if any PY code uses @handler,14
+gramex.transforms.transforms.handler_expr,log.handlers.user.keys,4
+gramex.transforms.transforms.handler_expr,log.handlers.requests.keys,4
+gramex.transforms.transforms.handler_expr,gramexlog,4
+gramex.transforms.transforms.build_log_info,log.handlers.user.keys,5
+gramex.transforms.transforms.build_log_info,log.handlers.requests.keys,5
+gramex.transforms.transforms.build_log_info,gramexlog,5
+gramex.transforms.twitterstream.*,TODO - if any PY code uses TwitterStream,44
+gramexenterprise.handlers.authhandler.OAuth2.*,url.*.handler=OAuth2,15
+gramexenterprise.handlers.authhandler.FacebookAuth.*,url.*.handler=FacebookAuth,2
+gramexenterprise.handlers.authhandler.TwitterAuth.*,url.*.handler=TwitterAuth,3
+gramexenterprise.handlers.authhandler.SAMLAuth.*,url.*.handler=SAMLAuth,9
+gramexenterprise.handlers.authhandler.SAMLAuth2.*,url.*.handler=SAMLAuth2,10
+gramexenterprise.handlers.authhandler.LDAPAuth.*,url.*.handler=LDAPAuth,15
+gramexenterprise.handlers.authhandler.DBAuth.*,url.*.handler=DBAuth,49
+gramexenterprise.handlers.authhandler.IntegratedAuth.*,url.*.handler=IntegratedAuth,13
+gramexenterprise.handlers.authhandler.SMSAuth.*,url.*.handler=SMSAuth,7
+gramexenterprise.handlers.authhandler.EmailAuth.*,url.*.handler=EmailAuth,10

--- a/reports/gramexsize.csv
+++ b/reports/gramexsize.csv
@@ -23,7 +23,7 @@ gramex.cache.JSONStore.*,app.session.type=json,15
 gramex.cache.JSONStore.*,url.*.kwargs.store.type=json,15
 gramex.cache.*,cache,49
 gramex.config.*,*,158
-gramex.data.*,url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler,320
+gramex.data.*,url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler,326
 gramex.debug.*,TODO - if any PY code uses gramex.debug,32
 gramex.install.*,TODO - Gramex app installation & management,128
 gramex.license.*,TODO - Gramex enterprise license management,9

--- a/reports/loc.csv
+++ b/reports/loc.csv
@@ -1,0 +1,4 @@
+type,loc
+Python,21983
+JavaScript,3859
+Tests,14846

--- a/task
+++ b/task
@@ -33,13 +33,13 @@ test () {
 
 stats () {
   # Get complexity of each part of Gramex and Gramex Enterprise. Save in reports/
-  python pkg/usage/gramexsize.py . ../gramexenterprise/ > reports/gramexsize.csv
+  python pkg/usage/gramexsize.py . ../gramexenterprise/ | tr -d '\r' > reports/gramexsize.csv
 
   # Count number of lines of code
-  PYLOC=`find gramex -name '*.py' ! -path '*/node_modules/*' | grep '\.py$' | xargs wc -l | tail -1`
-  JSLOC=`find gramex -name '*.js' ! -path '*/node_modules/*' | grep '\.js$' | xargs wc -l | tail -1`
-  TESTLOC=`find tests testlib pytest -name '*.py' ! -path '*node_modules/*' | grep '\.py$' | xargs wc -l | tail -1`
-  printf "Python: $PYLOC\nJavaScript: $JSLOC\nTests: $TESTLOC\n"
+  PYLOC=`find gramex -name '*.py' ! -path '*/node_modules/*' | grep '\.py$' | xargs wc -l | tail -1 | sed 's/[^0-9]//g'`
+  JSLOC=`find gramex -name '*.js' ! -path '*/node_modules/*' | grep '\.js$' | xargs wc -l | tail -1 | sed 's/[^0-9]//g'`
+  TESTLOC=`find tests testlib pytest -name '*.py' ! -path '*node_modules/*' | grep '\.py$' | xargs wc -l | tail -1 | sed 's/[^0-9]//g'`
+  printf "type,loc\nPython,$PYLOC\nJavaScript,$JSLOC\nTests,$TESTLOC\n" | tee reports/loc.csv
 }
 
 docs () {

--- a/task
+++ b/task
@@ -32,6 +32,9 @@ test () {
 }
 
 stats () {
+  # Get complexity of each part of Gramex and Gramex Enterprise. Save in reports/
+  python pkg/usage/gramexsize.py . ../gramexenterprise/ > reports/gramexsize.csv
+
   # Count number of lines of code
   PYLOC=`find gramex -name '*.py' ! -path '*/node_modules/*' | grep '\.py$' | xargs wc -l | tail -1`
   JSLOC=`find gramex -name '*.js' ! -path '*/node_modules/*' | grep '\.js$' | xargs wc -l | tail -1`
@@ -64,6 +67,7 @@ update () {
 }
 
 security () {
+  # Run all security tests
   bandit gramex --aggregate vuln --recursive --exclude '*/node_modules/*' > reports/bandit.txt
   freshclam
   clamscan --recursive --exclude-dir=.git --exclude-dir=__pycache__ --exclude-dir=mkdocs --exclude-dir=.eggs --exclude-dir=node_modules > reports/clamav.txt


### PR DESCRIPTION
This creates a `reports/gramexsize.csv` that shows cyclomatic complexity of Gramex features.

`gramexsize.yaml` has a `code2yaml`. It maps

- from Python wildcard paths (e.g. modules like `gramex.cache.*` or methods like `gramex.handlers.basehandler.BaseMixin.setup`)
- to YAML wildcard paths (e.g. `url.*.handler=FormHandler|FilterHandler|MLHandler|DriverHandler`)

It calculates the complexity of the Python paths, and saves it along with the YAML paths in `reports/gramexsize.csv`.

In a project, we can match the YAML paths used, and calculate the corresponding Python complexity. This gives us the complexity of the Gramex features used.