### PR TITLE
npm EACCESS error fixing

### DIFF
--- a/pkg/docker-gramex/Dockerfile
+++ b/pkg/docker-gramex/Dockerfile
@@ -16,7 +16,10 @@ RUN \
         # https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-on-alpine
         chromium nss freetype harfbuzz ca-certificates ttf-freefont && \
     # Activate conda env to run Gramex
-    source ~/.profile && \
+    mkdir ~/.npm-global && \
+    npm config set prefix '~/.npm-global'
+ENV PATH=~/.npm-global/bin:${PATH}
+RUN source ~/.profile && \
     # Set up all Gramex apps
     gramex setup --all && \
     # Clean up npm cache


### PR DESCRIPTION
The docker file wont install any NPM packages as this is a known NPM issue "EACCESS ISSUE" as shown below:
```sh
/app $ npm i
npm ERR! code 243
npm ERR! path /app/node_modules/js-captcha
npm ERR! command failed
npm ERR! command sh -c npm install -g np npm-check-updates
npm ERR! npm ERR! code EACCES
npm ERR! npm ERR! syscall mkdir
npm ERR! npm ERR! path /usr/local/lib/node_modules
npm ERR! npm ERR! errno -13
npm ERR! npm ERR! Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules'
npm ERR! npm ERR!  [Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules'] {
npm ERR! npm ERR!   errno: -13,
npm ERR! npm ERR!   code: 'EACCES',
npm ERR! npm ERR!   syscall: 'mkdir',
npm ERR! npm ERR!   path: '/usr/local/lib/node_modules'
npm ERR! npm ERR! }
npm ERR! npm ERR! 
npm ERR! npm ERR! The operation was rejected by your operating system.
npm ERR! npm ERR! It is likely you do not have the permissions to access this file as the current user
npm ERR! npm ERR! 
npm ERR! npm ERR! If you believe this might be a permissions issue, please double-check the
npm ERR! npm ERR! permissions of the file and its containing directories, or try running
npm ERR! npm ERR! the command again as root/Administrator.
npm ERR! 
npm ERR! npm ERR! A complete log of this run can be found in:
npm ERR! npm ERR!     /home/gramex/.npm/_logs/2022-11-30T18_26_02_926Z-debug-0.log

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/gramex/.npm/_logs/2022-11-30T18_25_23_443Z-debug-0.log
```

The solution is to create a new global NPM directory for the user and use that directory for caching and installation. Like so,

```sh
mkdir ~/.npm-global
npm config set prefix '~/.npm-global'
export PATH=~/.npm-global/bin:$PATH
source ~/.profile
```

This solution have been implemented as a remedy. In this PR 