### PR TITLE
FIX: OpenAPIHandler spec for FunctionHandler supports POST-only

### DIFF
--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -2522,12 +2522,12 @@ url:
     handler: FunctionHandler
     kwargs:
       function: utils.test_function
-      methods: GET, POST
+      methods: POST, PUT
     openapi:
-      get:
+      put:
         responses:
-          "400":
-            description: You served a bad request
+          "429":
+            description: Rate limited
 
   openapi/form:
     pattern: /openapi/form


### PR DESCRIPTION
If a FunctionHandler has only a POST method, the code auto-adds a GET with a summary. (Because we do that by default for all handlers.)

This commit fixes that.

We were also updating the DEFAULT OpenAPI specs with each handler's specs. So the specs were over-writing each other.

Now we make a copy of the spec before updating it.