### PR TITLE
FIX: FileHandler permits Gramex apps files under .conda

### DIFF
--- a/gramex/gramex.yaml
+++ b/gramex/gramex.yaml
@@ -64,7 +64,9 @@ handlers:
       - gramex*.yaml # Always ignore gramex config files
       - ".*" # Hide dotfiles
       - "*.py*" # Hide Python scripts
-    allow: ".allow" # Allow special dotfile
+    allow:
+      - ".allow" # Allow special dotfile
+      - "*/.conda/*/site-packages/gramex/apps/*"  # Allow Gramex apps code if exposed
 
   FormHandler:
     formats: &FORMATS


### PR DESCRIPTION
By default, FileHandler ignores files/folders beginning with `.`.
Conda installs non-root environments in a .conda folder.
If Gramex is installed in a non-root environment,
app-related files like logviewer's index.html won't be displayed.

This PR allows any gramex/apps/ files under a .conda folder.
The `allow:` is very specific to expose as few files are possible.