### PR TITLE
ENH: gramex.data.* functions accept argstype to typecast args

### DIFF
--- a/gramex/handlers/filterhandler.py
+++ b/gramex/handlers/filterhandler.py
@@ -3,4 +3,5 @@ from .formhandler import FormHandler
 
 
 class FilterHandler(FormHandler):
-    data_filter_method = staticmethod(gramex.data.filtercols)
+    def data_filter_method(*args, **kwargs):
+        gramex.data.filtercols(*args, **kwargs)

--- a/gramex/handlers/formhandler.py
+++ b/gramex/handlers/formhandler.py
@@ -42,7 +42,9 @@ class FormHandler(BaseHandler):
         'queryfunction': {'args': None, 'key': None, 'handler': None},
         'state': {'args': None, 'key': None, 'handler': None},
     }
-    data_filter_method = staticmethod(gramex.data.filter)
+
+    def data_filter_method(self, *args, **kwargs):
+        return gramex.data.filter(*args, **kwargs)
 
     @classmethod
     def setup(cls, **kwargs):
@@ -153,7 +155,6 @@ class FormHandler(BaseHandler):
         for key, dataset in self.datasets.items():
             meta[key] = AttrDict()
             opt = self._options(dataset, self.args, path_args, path_kwargs, key)
-            opt.filter_kwargs.pop('id', None)
             # Run query in a separate threadthread
             futures[key] = gramex.service.threadpool.submit(
                 self.data_filter_method, args=opt.args, meta=meta[key], **opt.filter_kwargs

--- a/pytest/test_data.py
+++ b/pytest/test_data.py
@@ -10,7 +10,8 @@ import dbutils  # noqa
 
 folder = os.path.dirname(os.path.abspath(__file__))
 sales_file = os.path.join(folder, '..', 'tests', 'sales.xlsx')
-sales_data: pd.DataFrame = gramex.cache.open(sales_file)
+sales_data: pd.DataFrame = gramex.cache.open(sales_file, sheet_name='sales')
+dates_data: pd.DataFrame = gramex.cache.open(sales_file, sheet_name='dates')
 
 
 @contextmanager
@@ -20,7 +21,7 @@ def dataframe():
 
 @contextmanager
 def sqlite():
-    url = dbutils.sqlite_create_db('test_delete.db', sales=sales_data)
+    url = dbutils.sqlite_create_db('test_delete.db', sales=sales_data, dates=dates_data)
     yield {'url': url, 'table': 'sales'}
     dbutils.sqlite_drop_db('test_delete.db')
 
@@ -28,7 +29,7 @@ def sqlite():
 @contextmanager
 def mysql():
     server = os.environ.get('MYSQL_SERVER', 'localhost')
-    url = dbutils.mysql_create_db(server, 'test_filter', sales=sales_data)
+    url = dbutils.mysql_create_db(server, 'test_filter', sales=sales_data, dates=dates_data)
     yield {'url': url, 'table': 'sales'}
     dbutils.mysql_drop_db(server, 'test_filter')
 
@@ -36,12 +37,15 @@ def mysql():
 @contextmanager
 def postgres():
     server = os.environ.get('POSTGRES_SERVER', 'localhost')
-    url = dbutils.postgres_create_db(server, 'test_filter', sales=sales_data)
+    url = dbutils.postgres_create_db(server, 'test_filter', sales=sales_data, dates=dates_data)
+    # Postgres needs a "ping" to connect to the database.
+    # Maybe related to https://stackoverflow.com/a/42546718/100904
+    gramex.data.filter(url=url, table='sales', args={'_limit': [1]})
     yield {'url': url, 'table': 'sales'}
     dbutils.postgres_drop_db(server, 'test_filter')
 
 
-setups = [dataframe, sqlite, mysql, postgres]
+db_setups = [dataframe, sqlite, mysql, postgres]
 delete_args = [
     {'देश': ['भारत']},
     {'city': ['Hyderabad', 'Bangalore']},
@@ -49,50 +53,132 @@ delete_args = [
 ]
 
 
-@pytest.mark.parametrize('args,setup', product(delete_args, setups))
-def test_delete(args, setup):
-    with setup() as kwargs:
+@pytest.mark.parametrize('args,db_setup', product(delete_args, db_setups))
+def test_delete(args, db_setup):
+    with db_setup() as kwargs:
         filter = None
         for key, vals in args.items():
             if filter is None:
                 filter = sales_data[key].isin(vals)
             else:
                 filter = filter & sales_data[key].isin(vals)
-        count = gramex.data.delete(args=args, **kwargs)
+        meta = {}
+        count = gramex.data.delete(args=args, meta=meta, **kwargs)
+        # TODO: validate meta
         assert count == filter.sum()
         result = gramex.data.filter(**kwargs)
         expected = sales_data[~filter]
         afe(result.reset_index(drop=True), expected.reset_index(drop=True))
 
 
+@contextmanager
+def check_argstype_sales():
+    query = '''
+        SELECT * FROM {table}
+        WHERE देश = :country
+        AND city IN :cities
+        AND product IN :products
+        AND sales > :salesmin
+    '''
+    args = {
+        'table': ['sales'],
+        'country': ['भारत'],
+        'cities': ['Hyderabad', 'Bangalore'],
+        'products': ['Crème'],
+        'salesmin': ['20'],
+    }
+    argstype = {
+        'cities': {'type': str, 'expanding': True},
+        'products': {'expanding': True},
+        'salesmin': 'float',
+    }
+    expected = sales_data[
+        (sales_data['देश'] == args['country'][0])
+        & (sales_data['city'].isin(args['cities']))
+        & (sales_data['product'].isin(args['products']))
+        & (sales_data['sales'] > float(args['salesmin'][0]))
+    ]
+    yield query, args, argstype, expected
+
+
+@contextmanager
+def check_argstype_dates():
+    query = '''
+        SELECT * FROM {table}
+        WHERE date BETWEEN :start AND :end
+        AND sales > :salesmin
+    '''
+    args = {
+        'table': ['dates'],
+        'start': ['2018-01-01'],
+        'end': ['31 Jan 2018 23:59:59'],
+        'salesmin': ['20'],
+    }
+    argstype = {
+        'start': 'date',
+        'end': 'pd.to_datetime',
+        'salesmin': 'int',
+    }
+    expected = dates_data[
+        (dates_data['date'] >= pd.to_datetime(args['start'][0]))
+        & (dates_data['date'] <= pd.to_datetime(args['end'][0]))
+        & (dates_data['sales'] > int(args['salesmin'][0]))
+    ]
+    yield query, args, argstype, expected
+
+
+argstype_args = [check_argstype_sales, check_argstype_dates]
+
+
+@pytest.mark.parametrize(
+    'args,db_setup',
+    product(
+        argstype_args,
+        db_setups[1:],  # Only test with databases, not dataframes
+    ),
+)
+def test_argstype(args, db_setup):
+    with db_setup() as kwargs:
+        with args() as (query, params, argstype, expected):
+            meta = {}
+            result = gramex.data.filter(
+                args=params, meta=meta, argstype=argstype, query=query, **kwargs
+            )
+            # SQLite stores dates as strings. Convert these
+            if 'date' in result.columns and not result['date'].dtype.name.startswith('date'):
+                result['date'] = pd.to_datetime(result['date'])
+            # TODO: Validate meta
+            afe(result.reset_index(drop=True), expected.reset_index(drop=True))
+
+
 filtercols_args = [
-    [
-        'sales|Range',
-        {'sales|min': [sales_data.sales.min()], 'sales|max': [sales_data.sales.max()]},
-    ],
-    [
-        'sales|Min',
-        {'sales|Min': [sales_data.sales.min()]},
-    ],
-    [
-        'sales,growth|Max',
-        {'sales|Max': [sales_data.sales.max()], 'growth|Max': [sales_data.growth.max()]},
-    ],
-    [
-        'sales,growth|Range',
-        {
+    {
+        '_c': 'sales|Range',
+        'out': {'sales|min': [sales_data.sales.min()], 'sales|max': [sales_data.sales.max()]},
+    },
+    {
+        '_c': 'sales|Min',
+        'out': {'sales|Min': [sales_data.sales.min()]},
+    },
+    {
+        '_c': 'sales,growth|Max',
+        'out': {'sales|Max': [sales_data.sales.max()], 'growth|Max': [sales_data.growth.max()]},
+    },
+    {
+        '_c': 'sales,growth|Range',
+        'out': {
             'sales|min': [sales_data.sales.min()],
             'sales|max': [sales_data.sales.max()],
             'growth|min': [sales_data.growth.min()],
             'growth|max': [sales_data.growth.max()],
         },
-    ],
+    },
 ]
 
 
-@pytest.mark.parametrize('args,setup', product(filtercols_args, setups))
+@pytest.mark.parametrize('args,setup', product(filtercols_args, db_setups))
 def test_filtercols(args, setup):
     with setup() as kwargs:
-        result = gramex.data.filtercols(args={'_c': [args[0]]}, **kwargs)
-        expected = pd.DataFrame(args[1])
-        afe(result[args[0]], expected)
+        result = gramex.data.filtercols(args={'_c': [args['_c']]}, **kwargs)
+        expected = pd.DataFrame(args['out'])
+        afe(result[args['_c']], expected)

--- a/tests/test_formhandler.py
+++ b/tests/test_formhandler.py
@@ -111,10 +111,11 @@ class TestFormHandler(TestGramex):
         # Non-existent column does not raise an error for any operation
         for op in ['', '~', '!', '>', '<', '<~', '>', '>~']:
             eq({'nonexistent' + op: ['']}, sales)
-        # Non-existent sorts do not raise an error
+        # Non-existent sorts do not raise an error.
+        # Also sort by sales AND देश to ensure a stable sort. (We need देश if sales is missing)
         eq(
-            {'_sort': ['nonexistent', 'sales']},
-            sales.sort_values('sales', na_position=na_position),
+            {'_sort': ['nonexistent', 'sales', 'देश']},
+            sales.sort_values(['sales', 'देश'], na_position=na_position),
         )
         # Non-existent _c does not raise an error
         eq({'_c': ['nonexistent', 'sales']}, sales[['sales']])


### PR DESCRIPTION
- ENH: argstype: converts URL args to Python types in SQL params
- ENH: argstype: supports expanding=True to bind iterable SQL params
- API: gramex.data.{update,delete,insert} use positional args before meta
- REF: data.{filter,update,delete,insert} have consistent signatures
- REF: Use data._convertor() for all internal type conversions
- REF: gramex.cache uses a single JSON dump with CustomJSONEncoder
- FIX: support filtering string columns that has NaN/NULL
- REF: improve type checking