### PR TITLE
FIX: FilterHandler overridden method should RETURN something!

### DIFF
--- a/gramex/handlers/filterhandler.py
+++ b/gramex/handlers/filterhandler.py
@@ -3,5 +3,5 @@ from .formhandler import FormHandler
 
 
 class FilterHandler(FormHandler):
-    def data_filter_method(*args, **kwargs):
-        gramex.data.filtercols(*args, **kwargs)
+    def data_filter_method(self, *args, **kwargs):
+        return gramex.data.filtercols(*args, **kwargs)

--- a/testlib/test_cache_module.py
+++ b/testlib/test_cache_module.py
@@ -414,7 +414,7 @@ class TestOpen(unittest.TestCase):
             frozenset(
                 [
                     ('header', 0),  # hashable values hashed as-is
-                    ('parse_dates', '{"date":[0,1,2]}'),  # converts to compact json if possible
+                    ('parse_dates', '[{"date":[0,1,2]}]'),  # converts to compact json if possible
                     ('dtype', None),  # gives up with None otherwise
                 ]
             ),


### PR DESCRIPTION
On a completely unrelated note, 0c5fd292 refactored the cache keys. Change the test case to reflect that.
This cache key change is (likely) a harmless, and might only require a restart. But need to keep an eye on this.