### PR TITLE
FIX: migration works on UNIX. Fixes #677

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ variables:
 validate:
   image: gramener/builderrors
   script: builderrors
-  # Until 31 Dec 2022, allow build errors to fail
+  # Until 31 Jan 2023, allow build errors to fail
   allow_failure: true
 
 # Deploy the master / release branches on gramener.com
@@ -43,9 +43,9 @@ deploy-gramener:
         cp -R /mnt/gramener/apps/gramex/gramex/apps/update /mnt/gramener/apps/v1/gramex-update;
       "'
 
-# Deploy the release branch additionally on UAT server
+# Deploy the master / release branches on uat.gramener.com
 deploy-uat:
-  only: [release]
+  only: [master, release]
   script:
     - 'ssh ubuntu@uat.gramener.com "
         cd ~/gramex;

--- a/gramex/migrate.py
+++ b/gramex/migrate.py
@@ -16,9 +16,7 @@ def user_db():
 
     # No need to migrate if developer specifies a storelocation.user different from default.
     url = objectpath(gramex.service, 'storelocations.user.url', '')
-
-    path = urlparse(url).path
-    path = path[1:].replace('\\', '/')
+    path = urlparse(url).path[1:].replace('\\', '/')
     default_path = variables['GRAMEXDATA'].replace('\\', '/').rstrip('/') + '/auth.user.db'
     if path != default_path:
         app_log.debug(f'1.87.0: SKIP migrating custom storelocations.user.url: {path}')


### PR DESCRIPTION
Gramex 1.87.0 requires migrating storelocation.user (auth.user.db) schema. We used BLOB earlier for SQLiteStore. We're moving to FormHandler, which requires TEXT.

Gramex 1.87.0 migrates the SQLite database to TEXT.

But the code was tested on Windows, not UNIX. On UNIX, the migration fails because the path comparison uses a different separator.

This commit fixes the issue.