### PR TITLE
ENH: Allow any debugger vai breakpoint() not pdb.set_trace()

### DIFF
--- a/gramex/gramex.yaml
+++ b/gramex/gramex.yaml
@@ -258,7 +258,7 @@ app:
     # default_host: 'host'          # Optional name of default host
     compress_response: True # GZip the HTTP response
 
-    # Debug=true enables all the below parameters, as well as Ctrl+D for pdb debugging on console
+    # Debug=true enables all the below parameters, as well as Ctrl+D for breakpoint on console
     debug: False # autoreload + !compiled_template_cache + !static_hash_cache + serve_traceback
     # Debug parameters
     # autoreload: False               # Reload Gramex when imported Python file changes

--- a/gramex/services/__init__.py
+++ b/gramex/services/__init__.py
@@ -163,9 +163,7 @@ def app(conf: dict) -> None:
                     # If Ctrl-D is pressed, run the Python debugger
                     char = debug.getch()
                     if char == b'\x04':
-                        import pdb  # noqa: T100
-
-                        pdb.set_trace()  # noqa: T100
+                        breakpoint()  # noqa: T100
                     # If Ctrl-B is pressed, start the browser
                     if char == b'\x02':
                         browser = webbrowser.get()


### PR DESCRIPTION
This lets developers use PYTHONBREAKPOINT=ipdb.set_trace or any other callable.

See https://peps.python.org/pep-0553/