### PR TITLE
FIX: schedules log full exception. Pipelines ignore logging errors

### DIFF
--- a/gramex/services/scheduler.py
+++ b/gramex/services/scheduler.py
@@ -78,7 +78,7 @@ class Task:
             def on_done(future):
                 exception = future.exception(timeout=0)
                 if exception:
-                    app_log.error(f'schedule:{name}: {exception}')
+                    app_log.exception(f'schedule:{name}: {exception}', exc_info=exception)
 
             def run_function(*args, **kwargs):
                 future = threadpool.submit(fn, *args, **kwargs)

--- a/gramex/transforms/transforms.py
+++ b/gramex/transforms/transforms.py
@@ -441,16 +441,19 @@ def build_pipeline(
                 from gramex.data import insert
 
                 end = datetime.datetime.utcnow().isoformat()
-                insert(
-                    **info.storelocations.pipeline,
-                    id=['name', 'start'],
-                    args={
-                        'name': [filename],
-                        'start': [start],
-                        'end': [end],
-                        'error': [error],
-                    },
-                )
+                try:
+                    insert(
+                        **info.storelocations.pipeline,
+                        id=['name', 'start'],
+                        args={
+                            'name': [filename],
+                            'start': [start],
+                            'end': [end],
+                            'error': [error],
+                        },
+                    )
+                except Exception:
+                    app_log.exception(f'pipeline:{filename} exception logging failed')
 
     return run_pipeline
 


### PR DESCRIPTION
Earlier, schedules printed a single line exception summary. Now, schedule exceptions show the full traceback.

Also, pipelines log exception info into a SQLite database. But this itself can fail. Capture and log that, but don't raise.