### PR TITLE
FIX: CommentHandler updates/deletes on flat args structure

### DIFF
--- a/gramex/handlers/commenthandler.py
+++ b/gramex/handlers/commenthandler.py
@@ -65,15 +65,14 @@ class CommentHandler(WebSocketHandler):
         method = message.setdefault('_method', 'post')
         args = {k: [v] for k, v in message.items() if k != '_method'}
         if method == 'post':
+            args['id'] = [urlsafe_b64encode(uuid4().bytes).strip(b"=").decode('utf-8')]
             args['user'] = [self.current_user.get('id', None) if self.current_user else None]
             args['timestamp'] = [time.time()]
-            args['id'] = [urlsafe_b64encode(uuid4().bytes).strip(b"=").decode('utf-8')]
             gramex.data.insert(**self.data, args=args)
         elif method == 'delete':
-            gramex.data.delete(**self.data, args={"id": [message["id"]]})
+            gramex.data.delete(**self.data, args=args)
         elif method == 'put':
-            updated_msg = {k: [v] for k, v in message['data'].items()}
-            gramex.data.update(**self.data, args=updated_msg)
+            gramex.data.update(**self.data, args=args)
 
         if self.email and method in self.email.get('methods', ['post']):
             # Send message to all clients


### PR DESCRIPTION
Earlier, CommentHandler required an 'id' field for delete. The PUT method required args inside a 'data' field. Now, we've flattened it. args are used as is and processed using the ['_method'] key.