### PR TITLE
ENH: handler.get_ratelimit() returns ratelimit info

### DIFF
--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -199,6 +199,14 @@ url:
           keys: [env.HOME, daily]
           limit: 4
 
+  ratelimit/info:
+    pattern: /ratelimit/info
+    handler: FunctionHandler
+    kwargs:
+      function: handler.get_ratelimit()
+      ratelimit:
+        <<: *RATELIMIT_POOL1
+
   ratelimit/reset:
     pattern: /ratelimit/reset
     handler: FunctionHandler

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -411,3 +411,18 @@ class TestRateLimit(TestGramex):
         self.check('/ratelimit/reset2')
         # Pool: None: 2/3, alpha: 2/3, beta: 1/3, all: 0/4
         self.check_rate('/ratelimit/ab', 'beta', 3, 1)
+
+    def test_get_ratelimit(self):
+        self.check('/ratelimit/reset')
+
+        def check(limit, usage):
+            result = self.check('/ratelimit/info').json()
+            eq_(result['limit'], limit)
+            eq_(result['usage'], usage)
+            eq_(result['remaining'], max(limit - usage - 1, 0))
+            ok_(result['expiry'] < 86400)
+
+        check(limit=3, usage=0)
+        check(limit=3, usage=1)
+        check(limit=3, usage=2)
+        self.check('/ratelimit/info', code=TOO_MANY_REQUESTS)


### PR DESCRIPTION
This is useful for programmatically checking the number of requests remaining for the URL.