### PR TITLE
FIX: HTTP 403 template works with any user object. Fixes #731

### DIFF
--- a/gramex/handlers/403.html
+++ b/gramex/handlers/403.html
@@ -32,7 +32,11 @@
     {% elif handler.current_user %}
       <p>You are logged in, but as a user that cannot access this page.</p>
       {% import yaml %}
-      <pre>{{ yaml.safe_dump(handler.current_user, default_flow_style=False) }}</pre>
+      {% try %}
+        <pre>{{ yaml.safe_dump(handler.current_user, default_flow_style=False) }}</pre>
+      {% except Exception %}
+        <pre>{{ handler.current_user }}</pre>
+      {% end %}
       {% if login_url %}<p><a href="{{ login_url }}">Try logging in again</a>.</p>{% end %}
     {% else %}
       <p>You <strong>are not</strong> logged in.</p>


### PR DESCRIPTION
If handler.current_user has any non-YAML-encodable object, the HTTP 403 template currently fails.

This commit captures any YAML dump exception, and instead just prints repr(handler.current_user) as an alternative.