### PR TITLE
ENH: add extra columns to storelocations.otp. Fixes #736

### DIFF
--- a/gramex/gramex.yaml
+++ b/gramex/gramex.yaml
@@ -365,9 +365,9 @@ storelocations:
     url: sqlite:///$GRAMEXDATA/auth.recover.db
     table: users
     columns:
+      token: {type: TEXT, primary_key: true}
       user: TEXT
       type: TEXT
-      token: TEXT
       expire: REAL # Seconds since epoch
   # Store pipeline execution runs. See gramex/transforms/transforms.py
   pipeline:

--- a/tests/gramex.yaml
+++ b/tests/gramex.yaml
@@ -2944,6 +2944,8 @@ storelocations:
   # The `otp:` section defines where to store one-time passwords
   otp:
     url: sqlite:///$YAMLPATH/otp.db
+    columns:
+      extra: TEXT
   userlog:
     columns:
       event: TEXT

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -253,13 +253,17 @@ def set_session(handler, **kwargs):
 
 
 def otp(handler):
-    expire = int(handler.get_argument('expire', '0'))
-    return json.dumps(handler.otp(expire=expire))
+    kwargs = {'expire': int(handler.get_argument('expire', '0'))}
+    if 'extra' in handler.args:
+        kwargs['extra'] = handler.get_argument('extra')
+    return json.dumps(handler.otp(**kwargs))
 
 
 def apikey(handler):
-    user = {key: val[-1] for key, val in handler.args.items()}
-    return json.dumps(handler.apikey(user=user or None))
+    kwargs = {'user': {key: val[-1] for key, val in handler.args.items()} or None}
+    if 'extra' in handler.args:
+        kwargs['extra'] = handler.get_argument('extra')
+    return json.dumps(handler.apikey(**kwargs))
 
 
 def revoke(handler):


### PR DESCRIPTION
## OTP custom keys

OTPs and API keys store a user object as JSON. You can add additional keys to this object with this configuration.

```yaml
storelocations:
  otp:
    columns:
      role: TEXT
      group: TEXT
```

The `columns:` are specified like [FormHandler columns](https://gramener.com/gramex/guide/formhandler/#formhandler-columns).

You can populate these columns using keyword arguments to `handler.otp()` and `handler.api_key()`

```python
handler.otp(user={"id": "alpha"}, role="admin", group="all")
# OR...
handler.api_key(user={"id": "alpha"}, role="admin", group="all")
```

When the user logs in with the OTP or API key, the user object will be

```json
{"id": "alpha", "role": "admin", "group": "all"`}
```

Of course, this could also be written as

```python
handler.otp(user={"id": "alpha", "role": "admin", "group": "all"`})
```
But using columns like this makes it easy to query fields, e.g. to delete OTPs for all `role="admin"`.