### PR TITLE
FIX: DriveHandler supports JSON body for PUT/DELETE. Fixes #738

### DIFF
--- a/gramex/handlers/basehandler.py
+++ b/gramex/handlers/basehandler.py
@@ -1173,6 +1173,13 @@ class BaseMixin:
         if self._set_xsrf:
             self.xsrf_token
 
+    def update_body_args(self):
+        '''Update self.args with JSON body if Content-Type is application/json'''
+        if self.request.body:
+            content_type = self.request.headers.get('Content-Type', '')
+            if content_type == 'application/json':
+                self.args.update(json.loads(self.request.body))
+
 
 class BaseHandler(RequestHandler, BaseMixin):
     '''

--- a/gramex/handlers/formhandler.py
+++ b/gramex/handlers/formhandler.py
@@ -111,12 +111,12 @@ class FormHandler(BaseHandler):
                         iter=False,
                     )
 
+    def prepare(self):
+        self.update_body_args()
+        super(FormHandler, self).prepare()
+
     def _options(self, dataset, args, path_args, path_kwargs, key):
         """For each dataset, prepare the arguments."""
-        if self.request.body:
-            content_type = self.request.headers.get('Content-Type', '')
-            if content_type == 'application/json':
-                args.update(json.loads(self.request.body))
         filter_kwargs = AttrDict(dataset)
         filter_kwargs.pop('modify', None)
         prepare = filter_kwargs.pop('prepare', None)


### PR DESCRIPTION
Earlier, FormHandler parsed JSON body inside the `post()`, `put()` or `delete()` methods.

`self.args` in subclasses like DriveHandler don't have the JSON body in it until these methods are called, which is sometimes too late (e.g. if we want to do something BEFORE delete.)

This commit moves the JSON body parsing into the `prepare()` method which is called first.