### PR TITLE
ENH: Add sentry service

### DIFF
--- a/gramex/handlers/basehandler.py
+++ b/gramex/handlers/basehandler.py
@@ -5,6 +5,7 @@ import json
 import time
 import logging
 import mimetypes
+import sentry_sdk
 import traceback
 import tornado.gen
 import gramex
@@ -367,10 +368,10 @@ class BaseMixin:
         # So use cookiepath: instead.
         if 'cookiepath' in session_conf:
             cls._session_cookie['path'] = session_conf['cookiepath']
-        cls._on_init_methods.append(cls.override_user)
-        cls._on_finish_methods.append(cls.set_last_visited)
+        # Ensure that sentry is set up AFTER we override the user
+        cls._on_init_methods += [cls.override_user, cls.setup_sentry]
         # Ensure that session is saved AFTER we set last visited
-        cls._on_finish_methods.append(cls.save_session)
+        cls._on_finish_methods += [cls.set_last_visited, cls.save_session]
 
     @classmethod
     def setup_ratelimit(
@@ -1208,6 +1209,9 @@ class BaseMixin:
                 raise MissingArgumentError(name)
             return default
         return self.args[name][0 if first else -1]
+
+    def setup_sentry(self):
+        sentry_sdk.set_user(self.current_user)
 
 
 class BaseHandler(RequestHandler, BaseMixin):

--- a/gramex/services/__init__.py
+++ b/gramex/services/__init__.py
@@ -31,6 +31,7 @@ import gramex.cache
 import gramex.license
 import logging.config
 import concurrent.futures
+import sentry_sdk
 from copy import deepcopy
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from tornado.template import Template
@@ -126,6 +127,9 @@ def app(conf: dict) -> None:
             app_log.info(f'Listening on port {conf.listen.port}')
             app_log_extra['port'] = conf.listen.port
             msg = f'Gramex {__version__} listening on http://127.0.0.1:{conf.listen.port}/. '
+            sentry_sdk.set_tag('port', conf.listen.port)
+            sentry_sdk.set_tag('gramex', __version__)
+            sentry_sdk.set_tag('cwd', os.getcwd())
 
             # browser: True opens the application home page on localhost.
             # browser: url opens the application to a specific URL
@@ -838,6 +842,13 @@ def create_alert(name, alert):
         return args
 
     return run_alert
+
+
+def sentry(conf: dict) -> None:
+    '''Set up sentry service'''
+    from sentry_sdk.integrations.tornado import TornadoIntegration
+
+    sentry_sdk.init(**conf, integrations=[TornadoIntegration()])
 
 
 def _markdown_convert(content):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
     "redis>=2.10.0",  # for RedisStore
     "requests",  # for all HTTP requests
     "seaborn",  # OPT: gramex.data.download()
+    "sentry",  # for sentry service
     "six",  # for gramex.yaml backward compatibility
     "sqlalchemy<2",  # for gramex.data.filter()
     "sqlitedict>=1.5.0",  # for SQLiteStore


### PR DESCRIPTION
Gramex integrates with [Sentry](https://sentry.io/) out-of-box.

First, [log into Sentry, create a project](https://docs.sentry.io/product/sentry-basics/integrate-frontend/create-new-project/) and copy the DSN key. 

Then, add this to `gramex.yaml`:

```yaml
sentry:
  dsn: "https://xxx@xxx.ingest.sentry.io/xxx"  # paste your DSN key
```

When Gramex reports any errors on the console, these are automatically sent to your [Sentry](https://sentry.io) instance. This works with [self-hosted sentry](https://develop.sentry.dev/self-hosted/) too.

Gramex adds the following information to each error:

1. The `gramex` tag set to the Gramex version (e.g. `1.92.0`)
2. The `cwd` tag is set to the current working directory (e.g. `C:\temp\`)
3. The `port` tag is set to the port Gramex is running on (e.g. `9988`)
4. The `user` is set based on the current user object (e.g. `{"id": "user@example.org", "role": "..."}`

You can pass [options to configure Sentry](https://docs.sentry.io/platforms/python/configuration/), like:

```yaml
sentry:
  dsn: "https://xxx@xxx.ingest.sentry.io/xxx"  # paste your DSN key
  sample_rate: 0.1
  server_name: my-server.example.com
  environment: production
```

Currently, only scalar options (text, numbers, booleans) are supported, not functions.